### PR TITLE
Modify the label used for CI failures

### DIFF
--- a/.github/workflows/auto-nightly-ci.yaml
+++ b/.github/workflows/auto-nightly-ci.yaml
@@ -30,5 +30,5 @@ jobs:
           title: "Night CI ${{ ENV.TIMESTAMP }}: Failed"
           body: |
             action url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          labels: "kind/bug"
+          labels: "kind/ci-bug"
           assignees: "weizhoublue"


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify the label used for CI failures，corrected kind/bug to kind/ci-bug

**make sure your commit is signed off**
Signed-off-by: ty-dc [tao.yang@daocloud.io](mailto:tao.yang@daocloud.io)