### PR TITLE
Fix IPv6 does not support rp_filter

### DIFF
--- a/pkg/agent/vxlan/vxlan.go
+++ b/pkg/agent/vxlan/vxlan.go
@@ -156,12 +156,6 @@ func (dev *Device) ensureFilter(ipv4, ipv6 *net.IPNet) error {
 			return err
 		}
 	}
-	if ipv6 != nil {
-		err := writeProcSys(fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/rp_filter", name), "2")
-		if err != nil {
-			return err
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
IPv6 不使用 rp_filter，ipv6 使用 [SAVI](https://www.rfc-editor.org/rfc/rfc7039.html)，我们在这个 PR 中停止对 IPv6 设置 rp_filter。前面我验证过 Egress IPv6 通讯正常，如果存在问题，我们会在另外的 PR 中解决。