### PR TITLE
Fix log wrapper

### DIFF
--- a/pkg/agent/eip.go
+++ b/pkg/agent/eip.go
@@ -110,6 +110,7 @@ type logWrapper struct {
 func (lw logWrapper) Log(keyVals ...interface{}) error {
 	fields := make([]zap.Field, 0, len(keyVals)/2)
 	var msgValue interface{}
+	var kind string
 	for i := 0; i < len(keyVals); i += 2 {
 		key, ok := keyVals[i].(string)
 		if !ok {
@@ -117,6 +118,8 @@ func (lw logWrapper) Log(keyVals ...interface{}) error {
 		}
 		if key == "msg" {
 			msgValue = keyVals[i+1]
+		} else if key == "level" {
+			kind = fmt.Sprintf("%v", keyVals[i+1])
 		} else {
 			fields = append(fields, zap.Any(key, keyVals[i+1]))
 		}
@@ -126,6 +129,17 @@ func (lw logWrapper) Log(keyVals ...interface{}) error {
 	if msgValue != nil {
 		msg = fmt.Sprintf("%v", msgValue)
 	}
-	lw.log.Error(msg, fields...)
+
+	switch kind {
+	case "debug":
+		lw.log.Debug(msg, fields...)
+	case "warn":
+		lw.log.Warn(msg, fields...)
+	case "error":
+		lw.log.Error(msg, fields...)
+	default:
+		lw.log.Info(msg, fields...)
+	}
+
 	return nil
 }


### PR DESCRIPTION
修复供 arp 宣告的日志模块 level 不一致问题
```json
{
  "level":"ERROR",                                              # 1
  "ts":"2023-06-29T08:26:24.495Z",
  "logger":"layer2",
  "caller":"agent/eip.go:129",
  "msg":"created NDP responder for interface",
  "level":"info",                                               # 2
  "interface":"calicc4b5600da7",
  "event":"createNDPResponder"
}
```