### PR TITLE
Fix path join empty will not add ''/'

### DIFF
--- a/pkg/agent/police.go
+++ b/pkg/agent/police.go
@@ -1124,7 +1124,7 @@ func enqueueEndpointSlice() handler.MapFunc {
 
 		if namespace == "" {
 			req := types.NamespacedName{
-				Namespace: path.Join("EgressClusterPolicy", namespace),
+				Namespace: "EgressClusterPolicy/",
 				Name:      policyName,
 			}
 			res = append(res, reconcile.Request{NamespacedName: req})

--- a/pkg/utils/flat.go
+++ b/pkg/utils/flat.go
@@ -6,6 +6,7 @@ package utils
 import (
 	"context"
 	"errors"
+	"path"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -18,10 +19,16 @@ var ErrInvalidRequest = errors.New("error invalid request")
 
 func KindToMapFlat(kind string) handler.MapFunc {
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		ns := obj.GetNamespace()
+		if ns == "" {
+			ns = kind + "/"
+		} else {
+			ns = path.Join(ns, kind)
+		}
 		return []reconcile.Request{
 			{
 				NamespacedName: types.NamespacedName{
-					Namespace: kind + "/" + obj.GetNamespace(),
+					Namespace: ns,
 					Name:      obj.GetName(),
 				},
 			},


### PR DESCRIPTION
如果 ns 为空，不使用 path.Join 去 join namespace 的值，它会导致我们在 namespace 的字段上得到一个 kind 类型的值，预期是 kind/namespace