### PR TITLE
Update crd docs

### DIFF
--- a/docs/concepts/Architecture.en.md
+++ b/docs/concepts/Architecture.en.md
@@ -1,0 +1,3 @@
+EgressGateway consists of two parts: the control plane and the data plane. The control plane is composed of four control loops, and the data plane is composed of three control loops. The control plane is deployed as a Deployment, supporting multiple replicas for high availability, and the data plane is deployed as a DaemonSet. The control loops are as follows in the diagram below:
+
+![arch](../proposal/03-egress-ip/arch.png)

--- a/docs/concepts/Architecture.zh.md
+++ b/docs/concepts/Architecture.zh.md
@@ -1,0 +1,116 @@
+EgressGateway 由控制面和数据面 2 部分组成，控制面由 4 个控制循环组成，数据面由 3 个控制循环组成。控制面以 Deployment 方式部署，支持多副本高可用，数据面以 DaemonSet 的方式部署。控制循环具体如下图：
+
+![arch](../proposal/03-egress-ip/arch.png)
+
+
+## Controller
+
+### EgressNode reconcile loop (a) 
+
+#### 初始化
+
+1. 从 ConfigMap 配置文件中获取双栈开启情况及对应的隧道 CIDR
+2. 通过节点名称根据算法生成唯一的标签值
+3. 会检查 Node 是否有对应的 EgressNode，没有的话就创建对应的 EgressNode，且状态设置为 `Pending`。有隧道 IP 则将 IP 与节点绑定，绑定前会检查 IP 是否合法，不合法则将状态设置为 `Pending`
+
+#### EgressNode Event
+
+- Del：先释放隧道 IP，再删除。如果 EgressNode 对应的节点还存在，重新创建 EgressNode
+- Other：
+  - phase != `Init` || phase != `Succeeded`：则分配 IP，分配成功将状态设置为 `Init`，分配失败将状态设置为 `Failed`。这里是全局唯一会分配隧道 IP 的地方
+  - mark != algorithm(NodeName)：该字段禁止修改，直接报错返回
+
+#### Node Event
+
+- Del：删除对应的 EgressNode
+- Other：
+  - 节点对应的 EgressNode 不存在，则创建 EgressNode
+  - 无隧道 IP，设置 phase 为 `Pending`
+  - 有隧道 IP，校验隧道是否合法，不合法则设置 phase 为 `Pending`
+  - 隧道 IP 合法，校验 IP 是否分配给本节点，不是则设置 phase 为 `Pending`
+  - 隧道 IP 是分配给本节点，phase 状态不为 `Succeeded` 则设置 phase 为 `Init`
+
+### EgressGateway reconcile loop (b)
+
+#### EgressGateway Event
+
+- Del：
+  * Webhook 判断是否还被其他 Policy 引用，如果存在则不允许删除。
+  * 通过了 Webhook 的校验说明没有被引用，所以的规则也被清理，则可以直接删除。
+
+- Other：
+  * EIP 减少，如果 EIP 被引用，禁止修改。分配 IPV4 与 IPV6 时，要求一一对应，所以两者的个数需要一致。
+  * 如果 nodeSelector 被修改，从 status 获取旧的 Node 信息，与最新的 Node 进行对比。将删除节点上的 EIP 重新分配到新的 Node 上。更新对应 EgressNode 中的 EIP 信息。
+
+#### EgressPolicy Event
+
+- Del：列出 EgressPolicy 找到被引用的 EgressGateway，再对 EgressPolicy 与 EgressGateway 解绑。解绑需要做的事情有，找到对应的 EIP 信息。如果使用了 EIP，则判断是否需要回收 EIP。如果此时 EIP 已经没有 policy 使用，则回收 EIP，更新自身及 EgressNode 的 EIP 信息。
+- Other：
+  * EgressPolicy 不能修改绑定的 EgressGateway。如果允许修改，则列出 EgressGateway 找到原先绑定的 EgressGateway，进行解绑。再对新的进行绑定。
+  * 新增 EgressPolicy，则将 EgressPolicy 与 EgressGateway 进行绑定，绑定中，判断是否需要分配 EIP。
+
+#### Node Event
+
+- Del：列出 EgressGateway 挑选出在该节点生效的 EIP，将这些 EIP 重新分配到新的节点上。更新 EgressGateway 的 eip.policy。
+- Other：
+  * NoReady 事件时，相当于触发删除事件。
+  * 标签修改，通过遍历 EgressGateway 所有信息，是否涉及 nodeSelector。如果旧标签不涉及 EgressPolicy，则不做任何处理。如果有涉及，相当于触发了删除事件。如果新的标签符合 EgressGateway 条件，则更新对应的 EgressGateway 的 status 信息。
+
+### EgressPolicy 选网关节点及 EIP 分配逻辑
+
+一个 EgressPolicy 会根据选网关节点的策略，选择一个节点作为网关节点。然后根据是否使用 EIP，来决定是否分配 EIP。分配的 EIP 将绑定到所选的网关节点上。
+
+分配逻辑都是以单个 EgressGateway 为对象，而不是所有的 EgressGateway。
+
+#### EgressPolicy 选网关节点的模式
+
+- 平均选择：当需要选择网关节点时，选择作为网关节点最少的一个节点。
+- 最少节点选择：尽量选同一个节点作为网关节点。
+- 限度选择：一个节点最多只能成为几个 EgressPolicy 的网关节点，限度可以设置，默认为 5。没有达到限度前，则优选选择该节点，达到限度就先选其他的节点，如果都达到了限度，则再随机选择。
+
+
+#### EIP 分配逻辑
+
+- 随机分配：在所有的 EIP 中随机选择一个，不管该 EIP 是否已经分配
+- 优先使用未分配的 EIP：先使用未分配的 EIP，如果都使用了则再随机分配一个已使用的 EIP
+- 限度选择：一个 EIP 最多只能被几个 EgressPolicy 使用，限度可以设置，默认为 5，没有达到限度前，则先分配该 EIP，达到限度则选其他的 EIP。都达到限度则随机分配。
+
+
+#### EIP 回收逻辑
+
+当一个 EIP 没有被使用时，则回收该 EIP，回收就是在 `eips` 中将该 EIP 字段删除。
+
+
+### EgressClusterInfo reconcile loop (d)
+
+#### Node Event
+
+- Create：node 创建时，将 node 的 ip 自动添加到 egressclusterinfos CR `status.egressIgnoreCIDR.nodeIP` 中。
+- Update：node ip 有更新时，将 node 的 ip 自动更新到 egressclusterinfos CR `status.egressIgnoreCIDR.nodeIP` 中。
+- Delete：node 被删除时，将 node 的 ip 从 egressclusterinfos CR `status.egressIgnoreCIDR.nodeIP` 中删除。
+
+#### Calico IPPool Event
+
+当 egressgateway 配置文件的 `egressIgnoreCIDR.autoDetect.podCIDR` 为 "calico" 时，监听 Calico 的 IPPool Event。
+- Create：Calico IPPool 创建时，将 IPPool CIDR 自动添加到 EgressClusterInfo CR `status.egressIgnoreCIDR.podCIDR` 中。
+- Update：calico IPPool 有更新时，将 IPPool CIDR 自动更新到 EgressClusterInfo CR `status.egressIgnoreCIDR.podCIDR` 中。
+- Delete：calico IPPool 被删除时，将 IPPool CIDR 从 EgressClusterInfo CR `status.egressIgnoreCIDR.podCIDR` 中删除。
+
+#### 配置文件
+
+修改配置文件，增加如下配置：
+
+```yaml
+feature:
+  egressIgnoreCIDR:
+    autoDetect:
+      podCIDR: ""      # 1
+      clusterIP: true  # 2
+      nodeIP: true     # 3
+    custom:
+      - "10.6.1.0/24"
+```
+
+1. `podCIDR`，目前支持 `calico`、`k8s`。默认为 `k8s`。
+2. `clusterIP`，支持设置为 Service CIDR 自动检测。
+3. `nodeIP`，支持设置为 Node IP 自动检测。

--- a/docs/crds/EgressClusterInfo.en.md
+++ b/docs/crds/EgressClusterInfo.en.md
@@ -1,0 +1,36 @@
+The EgressClusterInfo CRD introduces the Egress Ignore CIDR feature to simplify the configuration of Egress policies and allows automatic acquisition of the cluster's CIDR. When the `destSubnet` field of the EgressGatewayPolicy is empty, the data plane will automatically match traffic outside the CIDR in the EgressClusterStatus CR and forward it to the Egress gateway.
+
+```yaml
+apiVersion: egressgateway.spidernet.io/v1beta1
+kind: EgressClusterInfo
+metadata:
+  name: "default"    # 1
+spec: {}
+status:
+  egressIgnoreCIDR:  # 2
+    clusterIP:       # 3
+      ipv4:
+      - "172.41.0.0/16"
+      ipv6:
+      - "fd41::/108"
+    nodeIP:
+      ipv4:
+      - "172.18.0.3"
+      - "172.18.0.4"
+      - "172.18.0.2"
+      ipv6:
+      - "fc00:f853:ccd:e793::3"
+      - "fc00:f853:ccd:e793::4"
+      - "fc00:f853:ccd:e793::2"
+    podCIDR:
+      ipv4:
+      - "172.40.0.0/16"
+      ipv6:
+      - "fd40::/48"
+```
+
+1. The name defaults to `default`, maintained by the system, only one can be created, and it cannot be modified.
+2. `egressIgnoreCIDR` defines the CIDR that EgressGateway should ignore.
+3. `clusterIP` is the default service-cluster-ip-range for the cluster. Whether it is enabled is specified by the EgressGateway configuration file's default `egressIgnoreCIDR.autoDetect.clusterIP`.
+4. `nodeIP` is the collection of IP addresses for the cluster nodes (only taking the IP from the Node yaml `status.address`, in the case of multiple network cards, other network card IPs are treated as external IPs). Whether it is enabled is specified by the EgressGateway configuration file's default `egressIgnoreCIDR.autoDetect.nodeIP`.
+5. `podCIDR` is the CIDR used by the cluster's CNI. It is specified by the egressgateway configuration file's default `egressIgnoreCIDR.autoDetect.podCIDR`.

--- a/docs/crds/EgressClusterInfo.zh.md
+++ b/docs/crds/EgressClusterInfo.zh.md
@@ -1,8 +1,4 @@
-## 简介
-
-为了简化 Egress 策略的配置，引入 Egress Ignore CIDR 功能，允许自动获取集群的 CIDR。当 EgressGatewayPolicy 的 `destSubnet` 字段为空时，数据面将会自动匹配 EgressClusterStatus CR 中的 CIDR 之外的流量，并将其转发到 Egress 网关。
-
-## CRD
+EgressClusterInfo CRD 为了简化 Egress 策略的配置，引入 Egress Ignore CIDR 功能，允许自动获取集群的 CIDR。当 EgressGatewayPolicy 的 `destSubnet` 字段为空时，数据面将会自动匹配 EgressClusterStatus CR 中的 CIDR 之外的流量，并将其转发到 Egress 网关。
 
 ```yaml
 apiVersion: egressgateway.spidernet.io/v1beta1
@@ -34,50 +30,7 @@ status:
 ```
 
 1. 名称默认为 `default`，由系统维护，只能创建一个，不可被修改。
-2. `egressIgnoreCIDR` 定义 egressGateway 要忽略的 cidr。
-3. `clusterIP` 集群默认的 service-cluster-ip-range。是否开启，由 egressgateway 配置文件默认的 `egressIgnoreCIDR.autoDetect.clusterIP` 指定。
-4. `nodeIP` 集群节点的 IP（只取 node yaml `status.address` 中的 IP，多卡情况下，其他网卡 IP 被视作集群外 IP 处理）集合。是否开启，由 egressgateway 配置文件默认的 `egressIgnoreCIDR.autoDetect.nodeIP` 指定。
-5. `podCIDR` 集群的 cni 使用的 cidr。由 egressgateway 配置文件默认的 `egressIgnoreCIDR.autoDetect.podCIDR` 指定。
-
-## 代码设计
-
-### 初始化
-
-### Controller
-#### Node Event
-
-- Create：node 创建时，将 node 的 ip 自动添加到 egressclusterinfos CR `status.egressIgnoreCIDR.nodeIP` 中。
-- Update：node ip 有更新时，将 node 的 ip 自动更新到 egressclusterinfos CR `status.egressIgnoreCIDR.nodeIP` 中。
-- Delete：node 被删除时，将 node 的 ip 从 egressclusterinfos CR `status.egressIgnoreCIDR.nodeIP` 中删除。
-
-#### Calico IPPool Event
-
-当 egressgateway 配置文件的 `egressIgnoreCIDR.autoDetect.podCIDR` 为 "calico" 时，监听 Calico 的 IPPool Event。
-- Create：calico ippool 创建时，将 ippool cidr 自动添加到 egressclusterinfos CR `status.egressIgnoreCIDR.podCIDR` 中。
-- Update：calico ippool 有更新时，将 ippool cidr 自动更新到 egressclusterinfos CR `status.egressIgnoreCIDR.podCIDR` 中。
-- Delete：calico ippool 被删除时，将 ippool cidr 从 egressclusterinfos CR `status.egressIgnoreCIDR.podCIDR` 中删除。
-
-### Agent
-
-无
-
-## 其他
-
-### 配置文件
-
-修改配置文件，增加如下配置：
-
-```yaml
-feature:
-  egressIgnoreCIDR:
-    autoDetect:
-      podCIDR: ""      # 1
-      clusterIP: true  # 2
-      nodeIP: true     # 3
-    custom:
-      - "10.6.1.0/24"
-```
-
-1. `podCIDR`，目前支持 `calico`、`k8s`。默认为 `k8s`。
-2. `clusterIP`，支持设置为 Service CIDR 自动检测。
-3. `nodeIP`，支持设置为 Node IP 自动检测。
+2. `egressIgnoreCIDR` 定义 EgressGateway 要忽略的 CIDR。
+3. `clusterIP` 集群默认的 service-cluster-ip-range。是否开启，由 EgressGateway 配置文件默认的 `egressIgnoreCIDR.autoDetect.clusterIP` 指定。
+4. `nodeIP` 集群节点的 IP（只取 Node yaml `status.address` 中的 IP，多卡情况下，其他网卡 IP 被视作集群外 IP 处理）集合。是否开启，由 EgressGateway 配置文件默认的 `egressIgnoreCIDR.autoDetect.nodeIP` 指定。
+5. `podCIDR` 集群的 CNI 使用的 CIDR。由 egressgateway 配置文件默认的 `egressIgnoreCIDR.autoDetect.podCIDR` 指定。

--- a/docs/crds/EgressGateway.zh.md
+++ b/docs/crds/EgressGateway.zh.md
@@ -1,8 +1,4 @@
-## 简介
-
-用于选择一组节点作为 Egress 网关节点，Egress IP 可以在该范围浮动。集群级资源。
-
-## CRD
+The EgressGateway CRD is used to select a group of nodes as the Egress nodes of the cluster and configure the Egress IP pool for this group of nodes. The Egress IP can float within this range. Cluster scope resource.
 
 ```yaml
 apiVersion: egressgateway.spidernet.io/v1beta1
@@ -23,86 +19,33 @@ spec:
     selector:                   # 7
       matchLabels:
         egress: "true"
-    policy: "doing"   # 8
-status:                         # 9
-  nodeList:                     # 10
-    - name: "node1"             # 11
-      status: "Ready"           # 12
-      epis:                     # 13
-        - ipv4: "10.6.1.55"     # 14
-          ipv6: "fd00::55"      # 15
-          policies:             # 16
-            - name: "app"         # 17
-              namespace: "default"  # 18
+    policy: "doing"             # 8
+status:                         
+  nodeList:                     # 9
+    - name: "node1"             # 10
+      status: "Ready"           # 11
+      epis:                     # 12
+        - ipv4: "10.6.1.55"     # 13
+          ipv6: "fd00::55"      # 14
+          policies:             # 15
+            - name: "app"         # 16
+              namespace: "default"  # 17
 ```
 
-1. ippools: 设置 Egress IP 的范围；
-2. ipv4([]string): EIP 的 IPV4 内容，支持设置单个 IP `10.6.0.1` ，和段 `10.6.0.1-10.6.0.10 ` ， CIDR `10.6.0.1/26` 共3 种方式；
-3. ipv6([]string): EIP 的 IPV6 内容，如果开启双栈要求，IPv4 的数量和 IPv6 的数量要求一致，支持的格式与 IPV4 一致；
-4. ipv4DefaultEIP(string): 默认使用的 IPV4 EIP，如果 egp 未指定 EIP，且 EIP 分配的策略为 'default'，则该 egp 分配到的 EIP 就是 ipv4DefaultEIP；
-5. ipv6DefaultEIP(string): 默认使用的 IPV6 EIP，规则如 ipv4DefaultEIP；
-6. nodeSelector: 设置网关节点的匹配条件及策略
-7. selector: 设置节点的匹配内容
-8. policy(string): egp 选择网关节点的策略，目前只支持平均选择，其他策略待实现。
-9. status: 展示其所选网关节点、EIP 、被 policy 引用情况
-10. nodeList([]EgressIPStatus):
-11. name(string): 网关节点的名称
-12. status(string): 网关节点的状态
-13. eips([]Eips): 该网关节点上生效的 EIP 相关信息
-14. ipv4(string): IPV4 EIP，如果 egp、egcp 使用节点 IP，则该字段为空
-15. ipv6(string): IPV6 EIP，双栈情况下，IPV6 与 IPV4 是一一对应的
-16. policies([]string): 以该节点作为网关节点的 egp、egcp 集合
-17. name(string): egp、egcp 的名称
-18. namespace(string): egp 的 NS，如果是 egcp 则为空
-
-## 代码设计
-
-### 初始化
-
-### Controller
-#### EgressGateway Event
-- Del：
-    * webhook 判断是否还被其他 Policy 引用，如果存在则不允许删除。
-    * 通过了 webhook 的校验说明没有被引用，所以的规则也被清理，则可以直接删除
-
-- Other：
-    * EIP 减少，如果 EIP 被引用，禁止修改。分配 IPV4 与 IPV6 时，要求一一对应，所以两者的个数需要一致
-    * 如果 nodeSelector 被修改，从 status 获取旧的 Node 信息，与最新的 Node 进行对比。将删除节点上的 EIP 重新分配到新的 Node 上。更新对应 EgressNode 中的 EIP 信息。
-
-
-#### EgressGatewayPolicy Event
-- Del：list EgressEndpointSlice 找到被引用的 EgressGateway，再对 policy 与 EgressGateway 解绑。解绑需要做的事情有，找到对应的 EIP 信息。如果使用了 EIP，则判断是否需要回收 EIP。如果此时 EIP 已经没有 policy 使用，则回收 EIP，更新自身及 EgressNode 的 EIP 信息
-- Other：
-    * 暂定 policy 不能修改绑定的 EgressGateway。如果允许修改，则 list EgressGateway 找到原先绑定的 EgressGateway，进行解绑。再对新的进行绑定。
-    * 新增 policy，则将 policy 与 EgressGateway 进行绑定，绑定中，判断是否需要分配 EIP
-
-#### Node Event
-- Del：list EgressGateway 挑选出在该节点生效的 EIP，将这些 EIP 重新分配到新的节点上。更新 EgressGateway 的 eip.policy
-- Other：
-    * NoReady 事件时，相当于触发删除事件
-    * 标签修改，通过遍历 EgressGateway 所有信息，是否涉及 nodeSelector。如果旧标签不涉及 EgressPolicy，则不做任何处理。如果有涉及，相当于触发了删除事件。如果新的标签符合 EgressGateway 条件，则更新对应的 EgressGateway 的 status 信息
-
-
-### agent
-无
-
-## 其他
-### policy 选网关节点及 EIP 分配逻辑
-一个 policy 会根据选网关节点的策略，选择一个节点作为网关节点。然后根据是否使用 EIP，来决定是否分配 EIP。分配的 EIP 将绑定到所选的网关节点上
-
-分配逻辑都是以单个 EgressGateway 为对象，而不是所有的 EgressGateway。
-
-#### policy 选网关节点的模式
-- 平均选择：当需要选择网关节点时，选择作为网关节点最少的一个节点。
-- 最少节点选择：尽量选同一个节点作为网关节点
-- 限度选择：一个节点最多只能成为几个 policy 的网关节点，限度可以设置，默认为 5。没有达到限度前，则优选选择该节点，达到限度就先选其他的节点，如果都达到了限度，则再随机选择
-
-
-#### EIP 分配逻辑
-- 随机分配：在所有的 EIP 中随机选择一个，不管该 EIP 是否已经分配
-- 优先使用未分配的 EIP：先使用未分配的 EIP，如果都使用了则再随机分配一个已使用的 EIP
-- 限度选择：一个 EIP 最多只能被几个 policy 使用，限度可以设置，默认为 5，没有达到限度前，则先分配该 EIP，达到限度则选其他的 EIP。都达到限度则随机分配。
-
-
-#### EIP 回收逻辑
-当一个 EIP 没有被使用时，则回收该 EIP，回收就是在 eips 中将该 EIP 字段删除
+1. Set the range of egress IP pool that EgressGateway can use;
+2. Egress IPv4 pool, supporting three methods: single IP `10.6.0.1`, range `10.6.0.1-10.6.0.10`, and CIDR `10.6.0.1/26`;
+3. Egress IPv6 pool, if dual-stack requirements are enabled, the number of IPv4 and IPv6 must be consistent, and the format is the same as IPv4;
+4. The default IPv4 EIP to use. If the EgressPolicy does not specify EIP and the EIP assignment policy is `default`, the EIP assigned to this EgressPolicy will be `ipv4DefaultEIP`;
+5. The default IPv6 EIP to use, the rules are the same as `ipv6DefaultEIP`;
+6. Set the matching conditions and policy for egress nodes;
+7. Select a group of nodes as egress gateway nodes through Selector, and egress IP can float within this range;
+8. The policy for EgressGateway to select Egress nodes, currently only supports average selection;
+9. The egress nodes selected by node selector, as well as the effective egress IP on the node, and the EgressPolicy that uses this egress IP;
+10. The name of the Egress node;
+11. The status of the Egress node;
+12. The effective EIP information on this gateway node;
+13. Egress IPv4, if EgressPolicy and EgressClusterPolicy use node IP, this field is empty;
+14. Egress IPv6, in the dual-stack situation, IPv4 and IPv6 are one-to-one corresponding;
+15. Which policies are using the effective Egress IP on this node;
+16. Name of the Policy using the Egress IP;
+17. Namespace of the Policy using the Egress IP.

--- a/docs/crds/EgressNode.en.md
+++ b/docs/crds/EgressNode.en.md
@@ -1,0 +1,32 @@
+The EgressNode CRD is used to record tunnel network interface information for cross-node communication. It is a cluster scope resource that corresponds one-to-one with the Kubernetes Node resource name.
+
+```yaml
+apiVersion: egressgateway.spidernet.io/v1beta1
+kind: EgressNode
+metadata:
+   name: "node1"
+status:
+   tunnel:
+      ipv4: "192.200.222.157"  # 1
+      ipv6: "fd01::f2"         # 2        
+      mac: "66:50:85:cb:b2:bf" # 3
+      parent:
+         name: "ens160"        # 4
+         ipv4: "10.6.1.21/16"  # 5
+         ipv6: "fd00::21/112"  # 6
+   phase: "Succeeded"          # 7
+   mark: "0x26000000"          # 8
+```
+
+1. Tunnel IPv4 address
+2. Tunnel IPv6 address
+3. Tunnel MAC address
+4. Tunnel parent network interface
+5. Tunnel parent network interface IPv4 address
+6. Tunnel parent network interface IPv6 address
+7. Current tunnel status
+    - `Pending`: Waiting for IP allocation
+    - `Init`: Tunnel IP allocation successful
+    - `Succeeded`: Tunnel IP allocated and tunnel established
+    - `Failed`: Tunnel IP allocation failed
+8. Packet mark value, one for each node. For example, if node A has egress traffic that needs to be forwarded to gateway node B, the traffic of node A will be marked with a mark.

--- a/docs/crds/EgressNode.zh.md
+++ b/docs/crds/EgressNode.zh.md
@@ -1,8 +1,4 @@
-## 简介
-
-主要用于记录跨节点通信的隧道网卡信息。集群级资源，与 Kubernetes Node 资源名称一一对应。
-
-## CRD
+EgressNode CRD 用于记录跨节点通信的隧道网卡信息。这是一个集群级资源，它与 Kubernetes Node 资源名称一一对应。
 
 ```yaml
 apiVersion: egressgateway.spidernet.io/v1beta1
@@ -28,31 +24,9 @@ status:
 4. 隧道父网卡
 5. 隧道父网卡 IPv4 地址
 6. 隧道父网卡 IPv6 地址
-7. 当前隧道就绪阶段，`Succeeded` 隧道IP已分配，且隧道已建成，`Pending` 等待分配IP，`Init` 分配隧道 IP 成功，`Failed` 隧道 IP 分配失败
-8. mark 值，此为新增此段，创建时生成。每个节点对应一个，全局唯一的标签。标签由前缀 + 唯一标识符生成。标签格式如下 `NODE_MARK = 0x26 + value + 0000`，`value` 为 16 位，支持的节点总数为 `2^16`。在下发 policy 规则时所打的标签，取决于该规则的网关节点。
-
-## 代码设计
-
-### Controller
-
-#### 初始化
-
-1. 从 CM 中获取双栈开启情况及对应的隧道 CIDR
-2. 通过节点名称根据算法生成唯一的标签值
-3. 会检查 node 是否有对应的 EgressNode，没有的话就创建对应的EgressNode，且状态设置为 `Pending`。有隧道 IP 则将 IP 与节点绑定，绑定前会检查 IP 是否合法，不合法则将状态设置为 `Pending`
-
-#### EgressNode Event
-
-- Del：先释放隧道 IP，再删除。如果 EgressNode 对应的节点还存在，重新创建 EgressNode
-- Other：
-    - phase != `Init` || phase != `Succeeded`：则分配 IP，分配成功将状态设置为 `Init`，分配失败将状态设置为 `Failed`。这里是全局唯一会分配隧道 IP 的地方
-    - mark != algorithm(NodeName)：该字段禁止修改，直接报错返回
-
-#### Node Event
-- Del：删除对应的 EgressNode
-- Other：
-    - 节点对应的 EgressNode 不存在，则创建 EgressNode
-    - 无隧道 IP，设置 phase == `Pending`
-    - 有隧道 IP，校验隧道是否合法，不合法则设置 phase == `Pending`
-    - 隧道 IP 合法，校验 IP 是否分配给本节点，不是则设置 phase == `Pending`。
-    - 隧道 IP 是分配给本节点，phase != `Succeeded` 则设置 phase == `Init`
+7. 当前隧道状态
+    - `Pending`：等待分配 IP
+    - `Init`：分配隧道 IP 成功
+    - `Succeeded`：隧道 IP 已分配，且隧道已建成
+    - `Failed`：隧道 IP 分配失败
+8. 数据包 mark 值，每个节点对应一个。例如节点 A 的有 Egress 流量需要转发到网关节点 B，会对 A 节点的流量打 mark 进行标记。


### PR DESCRIPTION
* 我们在文档站二级菜单 CRD 下，仅介绍了 CRD 字段的定义以及使用场景。与 CRD 有关底层代码逻辑都移动到 架构 或 开发 的二级目录下。
* 增加中英文文档
* 优化标点，拼写，句子


