### PR TITLE
Update values

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -26,7 +26,7 @@ helm install egressgateway egressgateway/egressgateway --namespace kube-system
 | Name                                            | Description                                                                                                                | Value                   |
 | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
 | `feature.enableIPv4`                            | Enable IPv4                                                                                                                | `true`                  |
-| `feature.enableIPv6`                            | Enable IPv6                                                                                                                | `false`                 |
+| `feature.enableIPv6`                            | Enable IPv6                                                                                                                | `true`                  |
 | `feature.datapathMode`                          | iptables mode, [`iptables`, `ebpf`]                                                                                        | `iptables`              |
 | `feature.tunnelIpv4Subnet`                      | Tunnel IPv4 subnet                                                                                                         | `172.31.0.0/16`         |
 | `feature.tunnelIpv6Subnet`                      | Tunnel IPv6 subnet                                                                                                         | `fd11::/112`            |

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -25,7 +25,7 @@ feature:
   ## @param feature.enableIPv4 Enable IPv4
   enableIPv4: true
   ## @param feature.enableIPv6 Enable IPv6
-  enableIPv6: false
+  enableIPv6: true
   ## @param feature.datapathMode iptables mode, [`iptables`, `ebpf`]
   datapathMode: "iptables"
   ## @param feature.tunnelIpv4Subnet Tunnel IPv4 subnet


### PR DESCRIPTION
* 支持双栈的主机要大于不支持双栈的主机数量，所以将此 IPv6 开关打开。
* 使用 IPv4 集群的用户，使用 EgressGateway 默认 enableIPv4 和 enableIPv6 不受影响