### PR TITLE
Add `announcedInterfacesToExclude` configurations

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -41,6 +41,7 @@ helm install egressgateway egressgateway/egressgateway --namespace kube-system
 | `feature.egressIgnoreCIDR.autoDetect.nodeIP`    | if ignore node ip                                                                                                          | `true`                  |
 | `feature.egressIgnoreCIDR.custom`               | CIDRs provided manually                                                                                                    | `[]`                    |
 | `feature.maxNumberEndpointPerSlice`             | max number of endpoints per slice                                                                                          | `100`                   |
+| `feature.announcedInterfacesToExclude`          | The list of network interface excluded for announcing Egress IP.                                                           | `["^cali.*","br-*"]`    |
 
 ### Egressgateway agent parameters
 

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -58,6 +58,10 @@ feature:
     custom: []
   ## @param feature.maxNumberEndpointPerSlice max number of endpoints per slice
   maxNumberEndpointPerSlice: 100
+  ## @param feature.announcedInterfacesToExclude The list of network interface excluded for announcing Egress IP.
+  announcedInterfacesToExclude:
+    - "^cali.*"
+    - "br-*"
 
 ## @section Egressgateway agent parameters
 ##

--- a/pkg/agent/eip.go
+++ b/pkg/agent/eip.go
@@ -71,7 +71,7 @@ func (r *eip) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.R
 // newEipCtrl return a new egress ip controller
 func newEipCtrl(mgr manager.Manager, log logr.Logger, cfg *config.Config) error {
 	lw := logWrapper{log: log}
-	an, err := layer2.New(lw, nil)
+	an, err := layer2.New(lw, cfg.FileConfig.AnnounceExcludeRegexp)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
支持通过 announcedInterfacesToExclude 屏蔽不需要 arp 回复的网卡(解决 https://github.com/spidernet-io/egressgateway/pull/566 测试出的问题)
减少 cluster internal cidr ipset 函数的复杂度