### PR TITLE
Remove the usage output when running nettools

### DIFF
--- a/cmd/nettools/initFlag.go
+++ b/cmd/nettools/initFlag.go
@@ -29,7 +29,6 @@ func ParseFlag() Config {
 	}
 
 	flag.Parse()
-	flag.Usage()
 
 	return config
 }


### PR DESCRIPTION
### why?

每次运行的时候打印 usage 导致 e2e 日志太过冗长。查看用法使用 `tools --help` 即可。
