### PR TITLE
Fix nightly ci

### DIFF
--- a/.github/workflows/auto-pr-ci.yaml
+++ b/.github/workflows/auto-pr-ci.yaml
@@ -224,7 +224,11 @@ jobs:
 
   e2e_dual-ubuntu-20-04:
     needs: [call_build_ci_image, prepare]
-    if: ${{  always() && needs.prepare.outputs.e2e_enabled == 'true' && needs.prepare.outputs.ipfamily_dual_e2e == 'true' }}
+    # In Ubuntu 20.04, when installing k8s `1.23.*`+ using kind,
+    # there is an issue where it cannot be started. This is a
+    # compatibility problem with the `kindest/node` image in kind,
+    # and we are waiting for a fix from upstream.
+    if: ${{  always() && needs.prepare.outputs.e2e_enabled == 'true' && needs.prepare.outputs.ipfamily_dual_e2e == 'true' && (needs.prepare.outputs.kindNodeImage == 'kindest/node:v1.22.17' | needs.prepare.outputs.kindNodeImage == 'kindest/node:v1.23.17') }}
     uses: ./.github/workflows/call-e2e.yaml
     with:
       ref: ${{ needs.prepare.outputs.ref }}
@@ -236,7 +240,11 @@ jobs:
 
   e2e_ipv4-ubuntu-20-04:
     needs: [call_build_ci_image, prepare]
-    if: ${{  always() && needs.prepare.outputs.e2e_enabled == 'true' && needs.prepare.outputs.ipfamily_ipv4only_e2e == 'true' }}
+    # In Ubuntu 20.04, when installing k8s `1.23.*`+ using kind,
+    # there is an issue where it cannot be started. This is a
+    # compatibility problem with the `kindest/node` image in kind,
+    # and we are waiting for a fix from upstream.
+    if: ${{  always() && needs.prepare.outputs.e2e_enabled == 'true' && needs.prepare.outputs.ipfamily_ipv4only_e2e == 'true' && (needs.prepare.outputs.kindNodeImage == 'kindest/node:v1.22.17' | needs.prepare.outputs.kindNodeImage == 'kindest/node:v1.23.17') }}
     uses: ./.github/workflows/call-e2e.yaml
     with:
       ref: ${{ needs.prepare.outputs.ref }}
@@ -248,7 +256,11 @@ jobs:
 
   e2e_ipv6-ubuntu-20-04:
     needs: [call_build_ci_image, prepare]
-    if: ${{  always() && needs.prepare.outputs.e2e_enabled == 'true'  && needs.prepare.outputs.ipfamily_ipv6only_e2e == 'true' }}
+    # In Ubuntu 20.04, when installing k8s `1.23.*`+ using kind,
+    # there is an issue where it cannot be started. This is a
+    # compatibility problem with the `kindest/node` image in kind,
+    # and we are waiting for a fix from upstream.
+    if: ${{  always() && needs.prepare.outputs.e2e_enabled == 'true'  && needs.prepare.outputs.ipfamily_ipv6only_e2e == 'true' && (needs.prepare.outputs.kindNodeImage == 'kindest/node:v1.22.17' | needs.prepare.outputs.kindNodeImage == 'kindest/node:v1.23.17') }}
     uses: ./.github/workflows/call-e2e.yaml
     with:
       ref: ${{ needs.prepare.outputs.ref }}


### PR DESCRIPTION
ubuntu 20.04 with kind is not compatible with k8s 1.23.*+ (excluding `1.23.*`).

Fix:
https://github.com/spidernet-io/egressgateway/issues/627
https://github.com/spidernet-io/egressgateway/issues/625
https://github.com/spidernet-io/egressgateway/issues/602


Signed-off-by: lou-lan <loulan@loulan.me>