### PR TITLE
Add default egw

### DIFF
--- a/.github/codespell-ignorewords
+++ b/.github/codespell-ignorewords
@@ -1,0 +1,4 @@
+afterall
+pullrequest
+keypair
+shouldnot

--- a/charts/crds/egressgateway.spidernet.io_egressgateways.yaml
+++ b/charts/crds/egressgateway.spidernet.io_egressgateways.yaml
@@ -27,6 +27,10 @@ spec:
       jsonPath: .spec.ippools.ipv6DefaultEIP
       name: ipv6DefaultEIP
       type: string
+    - description: clusterDefault
+      jsonPath: .spec.clusterDefault
+      name: clusterDefault
+      type: boolean
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -46,6 +50,8 @@ spec:
             type: object
           spec:
             properties:
+              clusterDefault:
+                type: boolean
               ippools:
                 properties:
                   ipv4:

--- a/charts/templates/tls.yaml
+++ b/charts/templates/tls.yaml
@@ -102,6 +102,8 @@ webhooks:
           - UPDATE
         resources:
         - egressgateways
+        - egresspolicies
+        - egressclusterpolicies
     sideEffects: None
 
 {{- if eq .Values.controller.tls.method "certmanager" -}}

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -79,6 +79,9 @@ nav:
       - Install: usage/Install.md
       - Upgrade: usage/Upgrade.md
       - Uninstall: usage/Uninstall.md
+  - Usage:
+      - Namespace Default EgressGateway: usage/NamespaceDefaultEgressGateway.md
+      - Cluster Default EgressGateway: usage/ClusterDefaultEgressGateway.md
   - Concepts:
       - Architecture: concepts/Architecture.md
       - Datapath: concepts/Datapath.md

--- a/docs/usage/ClusterDefaultEgressGateway.en.md
+++ b/docs/usage/ClusterDefaultEgressGateway.en.md
@@ -1,0 +1,76 @@
+# Cluster level Default EgressGateway
+
+## Introduction
+
+Setting a default EgressGateway for the entire cluster can simplify the process of using EgressPolicy under a namespace or using EgressClusterPolicy at the cluster level, as it eliminates the need to specify the EgressGateway name each time. Please note that only one default EgressGateway can be set for the cluster.
+
+## Requirements
+
+- EgressGateway component is installed.
+
+## Steps
+
+1. When creating an EgressGateway, you can specify `spec.clusterDefault` as `true` to make it the default EgressGateway for the cluster. If `spec.egressGatewayName` is not specified in EgressClusterPolicy, and `spec.egressGatewayName` is not specified in EgressPolicy and the tenant has not configured a default EgressGateway, the cluster's default EgressGateway will be automatically used.
+
+   ```yaml
+   apiVersion: egressgateway.spidernet.io/v1beta1
+   kind: EgressGateway
+   metadata:
+     name: default
+   spec:
+     clusterDefault: true
+     ippools:
+       ipv4:
+         - 10.6.1.55
+         - 10.6.1.56
+       ipv4DefaultEIP: 10.6.1.55
+       ipv6:
+         - fd00::55
+         - fd00::56
+       ipv6DefaultEIP: fd00::56
+     nodeSelector:
+       selector:
+         matchLabels:
+           egress: "true"    
+   ```
+
+2. Use the following definition to create an EgressPolicy, ignoring the definition of the `spec.egressGatewayName` field:
+
+   ```yaml
+   apiVersion: egressgateway.spidernet.io/v1beta1
+   kind: EgressPolicy
+   metadata:
+     name: mock-app
+   spec:
+     appliedTo:
+       podSelector:
+         matchLabels:
+           app: mock-app
+     destSubnet:
+       - 10.6.1.92/32
+   ```
+
+3. Run the following command again to confirm that the EgressPolicy has been set to the default EgressGateway:
+
+   ```shell
+   $ kubectl get egresspolicies mock-app -o yaml
+   apiVersion: egressgateway.spidernet.io/v1beta1
+   kind: EgressPolicy
+   metadata:
+     creationTimestamp: "2023-08-09T11:54:34Z"
+     generation: 1
+     name: mock-app
+     namespace: default
+     resourceVersion: "6233341"
+     uid: 5692c5e6-a72b-41bd-a611-1106abd41bc2
+   spec:
+     appliedTo:
+       podSelector:
+         matchLabels:
+           app: mock-app
+     destSubnet:
+     - 10.6.1.92/32
+     - fd00::92/128
+     - 172.30.40.0/21
+     egressGatewayName: default
+   ```

--- a/docs/usage/ClusterDefaultEgressGateway.zh.md
+++ b/docs/usage/ClusterDefaultEgressGateway.zh.md
@@ -1,0 +1,76 @@
+# 集群级默认 EgressGateway
+
+## 介绍
+
+为整个集群设置默认 EgressGateway，可以简化在租户下使用 EgressPolicy 或在集群级使用 EgressClusterPolicy 时，每次指定 EgressGateway 名称的步骤。注意集群默认 EgressGateway 只能设置一个。
+
+## 实施要求
+
+* 已安装 EgressGateway 组件
+
+## 步骤
+
+1. 创建 EgressGateway 时可以通过指定 `spec.clusterDefault` 为 `true` 会被作为集群默认 EgressGateway，在 EgressClusterPolicy 没有指定 `spec.egressGatewayName` 时，以及 EgressPolicy 没有指定 指定 `spec.egressGatewayName` 且租户没有配置默认 EgressGateway 时，自动使用集群默认的 EgressGateway。
+
+    ```yaml
+    apiVersion: egressgateway.spidernet.io/v1beta1
+    kind: EgressGateway
+    metadata:
+      name: default
+    spec:
+      clusterDefault: true
+      ippools:
+        ipv4:
+          - 10.6.1.55
+          - 10.6.1.56
+        ipv4DefaultEIP: 10.6.1.55
+        ipv6:
+          - fd00::55
+          - fd00::56
+        ipv6DefaultEIP: fd00::56
+      nodeSelector:
+        selector:
+          matchLabels:
+            egress: "true"    
+    ```
+
+2. 使用以下定义创建 EgressPolicy，忽略 `spec.egressGatewayName` 字段的定义：
+
+    ```yaml
+    apiVersion: egressgateway.spidernet.io/v1beta1
+    kind: EgressPolicy
+    metadata:
+      name: mock-app
+    spec:
+      appliedTo:
+        podSelector:
+          matchLabels:
+            app: mock-app
+      destSubnet:
+        - 10.6.1.92/32
+    ```
+
+3. 再次运行以下命令，确认 EgressPolicy 已被设置为默认的 EgressGateway：
+
+    ```shell
+    $ kubectl get egresspolicies mock-app -o yaml
+    apiVersion: egressgateway.spidernet.io/v1beta1
+    kind: EgressPolicy
+    metadata:
+      creationTimestamp: "2023-08-09T11:54:34Z"
+      generation: 1
+      name: mock-app
+      namespace: default
+      resourceVersion: "6233341"
+      uid: 5692c5e6-a72b-41bd-a611-1106abd41bc2
+    spec:
+      appliedTo:
+        podSelector:
+          matchLabels:
+            app: mock-app
+      destSubnet:
+      - 10.6.1.92/32
+      - fd00::92/128
+      - 172.30.40.0/21
+      egressGatewayName: default
+    ```

--- a/docs/usage/Install.en.md
+++ b/docs/usage/Install.en.md
@@ -67,6 +67,7 @@ kind: EgressGateway
 metadata:
   name: default
 spec:
+  clusterDefault: true
   ippools:
     ipv4:
       - "10.6.1.60-10.6.1.66" # (1)  
@@ -114,18 +115,16 @@ kind: EgressPolicy
 metadata:
   name: mock-app
 spec:
-  egressGatewayName: "default" # (1)  
   appliedTo:
     podSelector:
-      matchLabels:             # (2)
+      matchLabels:             # (1)
         app: mock-app
   destSubnet:
-    - 10.6.1.92/32             # (3)
+    - 10.6.1.92/32             # (2)
 ```
 
-1. By setting this value, select the EgressGateway named `default` created above.
-2. Select Pods that need to perform Egress operations by setting `matchLabels`.
-3. By setting `destSubnet`, only matched Pods will perform Egress operations when accessing a specific subnet.
+1. Select Pods that need to perform Egress operations by setting `matchLabels`.
+2. By setting `destSubnet`, only matched Pods will perform Egress operations when accessing a specific subnet.
 
 Now, traffic from mock-app accessing 10.6.1.92 will be forwarded through the egress gateway.
 

--- a/docs/usage/Install.zh.md
+++ b/docs/usage/Install.zh.md
@@ -110,6 +110,7 @@ helm repo update
               name: default
               uid: 7ce835e2-2075-4d26-ba63-eacd841aadfe
             spec:
+              clusterDefault: true
               ippools:
                 ipv4:
                 - 172.22.0.100-172.22.0.110
@@ -145,7 +146,6 @@ EgressPolicy 对象是租户级别的，因此，它务必创建在 selected 应
           name: test
           namespace: default
         spec:
-          egressGatewayName: "default"
           appliedTo:
             podSelector:
               matchLabels:
@@ -176,7 +176,6 @@ EgressPolicy 对象是租户级别的，因此，它务必创建在 selected 应
             podSelector:
               matchLabels:
                 app: visitor
-          egressGatewayName: default
           egressIP:
             allocatorPolicy: default
             useNodeIP: false

--- a/docs/usage/NamespaceDefaultEgressGateway.en.md
+++ b/docs/usage/NamespaceDefaultEgressGateway.en.md
@@ -1,0 +1,59 @@
+# Namespace level Default EgressGateway
+
+## Introduction
+
+Setting a default EgressGateway for a namespace simplifies the process of specifying the EgressGateway name when using EgressPolicy under the namespace. The priority of the namespace level default EgressGateway is higher than the cluster level default EgressGateway. In other words, when a namespace level default gateway is specified, the tenant's default settings will be used first. If the namespace does not have a default gateway set, the cluster's default settings will be used.
+
+## Requirements
+
+- EgressGateway component is installed.
+- An EgressGateway CR has been created.
+
+## Steps
+
+1. Use the following command to specify the default EgressGateway name for the tenant:
+
+   ```bash
+   kubectl label ns default spidernet.io/egressgateway-default=egressgateway
+   ```
+
+2. Use the following definition to create an EgressPolicy, ignoring the definition of the `spec.egressGatewayName` field:
+
+   ```yaml
+   apiVersion: egressgateway.spidernet.io/v1beta1
+   kind: EgressPolicy
+   metadata:
+     name: mock-app
+   spec:
+     appliedTo:
+       podSelector:
+         matchLabels:
+           app: mock-app
+     destSubnet:
+       - 10.6.1.92/32
+   ```
+
+3. Run the following command again to confirm that the EgressPolicy has been set to the default EgressGateway:
+
+   ```shell
+   $ kubectl get egresspolicies mock-app -o yaml
+   apiVersion: egressgateway.spidernet.io/v1beta1
+   kind: EgressPolicy
+   metadata:
+     creationTimestamp: "2023-08-09T10:54:34Z"
+     generation: 1
+     name: mock-app
+     namespace: default
+     resourceVersion: "6233341"
+     uid: 5692c5e6-a71b-41bd-a611-1106abd41ba3
+   spec:
+     appliedTo:
+       podSelector:
+         matchLabels:
+           app: mock-app
+     destSubnet:
+     - 10.6.1.92/32
+     - fd00::92/128
+     - 172.30.40.0/21
+     egressGatewayName: egressgateway
+   ```

--- a/docs/usage/NamespaceDefaultEgressGateway.zh.md
+++ b/docs/usage/NamespaceDefaultEgressGateway.zh.md
@@ -1,0 +1,59 @@
+# 租户级默认 EgressGateway
+
+## 介绍
+
+为租户设置默认 EgressGateway 可以简化在租户下使用 EgressPolicy 时每次指定 EgressGateway 名称的步骤。租户级默认 EgressGateway 的优先级大于集群默认 EgressGateway，换句话说，当指定了租户级的默认网关，会优先使用租户默认设置，如果租户没有设置默认网关，则会使用集群默认设置。
+
+## 实施要求
+
+* 已安装 EgressGateway 组件
+* 已创建一个 EgressGateway CR
+
+## 步骤
+
+1. 使用以下命令为租户指定默认的 EgressGateway 名称：
+    
+    ```bash
+    kubectl label ns default spidernet.io/egressgateway-default=egressgateway
+    ```
+
+2. 使用以下定义创建 EgressPolicy，忽略 `spec.egressGatewayName` 字段的定义：
+
+    ```yaml
+    apiVersion: egressgateway.spidernet.io/v1beta1
+    kind: EgressPolicy
+    metadata:
+      name: mock-app
+    spec:
+      appliedTo:
+        podSelector:
+          matchLabels:
+            app: mock-app
+      destSubnet:
+        - 10.6.1.92/32
+    ```
+
+3. 再次运行以下命令，确认 EgressPolicy 已被设置为默认的 EgressGateway：
+
+    ```shell
+    $ kubectl get egresspolicies mock-app -o yaml
+    apiVersion: egressgateway.spidernet.io/v1beta1
+    kind: EgressPolicy
+    metadata:
+      creationTimestamp: "2023-08-09T10:54:34Z"
+      generation: 1
+      name: mock-app
+      namespace: default
+      resourceVersion: "6233341"
+      uid: 5692c5e6-a71b-41bd-a611-1106abd41ba3
+    spec:
+      appliedTo:
+        podSelector:
+          matchLabels:
+            app: mock-app
+      destSubnet:
+      - 10.6.1.92/32
+      - fd00::92/128
+      - 172.30.40.0/21
+      egressGatewayName: egressgateway
+    ```

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/vishvananda/netlink v1.2.1-beta.2.0.20230130171208-05506ada9f99
 	go.uber.org/zap v1.25.0
 	golang.org/x/sys v0.10.0
+	gomodules.xyz/jsonpatch/v2 v2.3.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.27.3
@@ -135,7 +136,6 @@ require (
 	golang.org/x/text v0.11.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.9.3 // indirect
-	gomodules.xyz/jsonpatch/v2 v2.3.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/pkg/controller/webhook/mutating.go
+++ b/pkg/controller/webhook/mutating.go
@@ -1,0 +1,152 @@
+// Copyright 2022 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"gomodules.xyz/jsonpatch/v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/spidernet-io/egressgateway/pkg/config"
+	"github.com/spidernet-io/egressgateway/pkg/egressgateway"
+	egressv1 "github.com/spidernet-io/egressgateway/pkg/k8s/apis/v1beta1"
+)
+
+// MutateHook MutateHook
+func MutateHook(client client.Client, cfg *config.Config) *webhook.Admission {
+	return &webhook.Admission{
+		Handler: admission.HandlerFunc(func(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
+
+			switch req.Kind.Kind {
+			case EgressGateway:
+				return (&egressgateway.EgressGatewayWebhook{Client: client, Config: cfg}).EgressGatewayMutate(ctx, req)
+			case EgressPolicy:
+				return mutateHookEgressPolicy(ctx, req, client)
+			case EgressClusterPolicy:
+				return mutateHookEgressClusterPolicy(ctx, req, client)
+			}
+
+			return webhook.Allowed("checked")
+		}),
+	}
+}
+
+func mutateHookEgressPolicy(ctx context.Context, req webhook.AdmissionRequest, cli client.Client) webhook.AdmissionResponse {
+	policy := new(egressv1.EgressPolicy)
+	err := json.Unmarshal(req.Object.Raw, policy)
+	if err != nil {
+		return webhook.Denied(fmt.Sprintf("json unmarshal EgressPolicy with error: %v", err))
+	}
+
+	patchList := make([]jsonpatch.JsonPatchOperation, 0)
+
+	if policy.Spec.EgressGatewayName == "" {
+		ns := &corev1.Namespace{}
+		err := cli.Get(ctx, types.NamespacedName{Name: policy.Namespace}, ns)
+		if err != nil {
+			return webhook.Denied(fmt.Sprintf("failed to get EgressPolicy namespaces: %v", err))
+		}
+		egw, ok := ns.Labels[egressv1.LabelNamespaceEgressGatewayDefault]
+		if !ok || egw == "" {
+			if policy.Spec.EgressGatewayName == "" {
+				p, err := getGlobalDefaultEgwPatch(ctx, cli)
+				if err != nil {
+					return webhook.Denied(err.Error())
+				}
+				if p != nil {
+					patchList = append(patchList, *p)
+				}
+			}
+		} else {
+			patchList = append(patchList, jsonpatch.JsonPatchOperation{
+				Operation: "add",
+				Path:      "/spec/egressGatewayName",
+				Value:     egw,
+			})
+		}
+	}
+
+	if policy.Spec.EgressIP.IsEmpty() {
+		patchList = append(patchList, jsonpatch.JsonPatchOperation{
+			Operation: "add",
+			Path:      "/spec/egressIP",
+			Value:     egressv1.EgressIP{UseNodeIP: false, AllocatorPolicy: "default"},
+		})
+	}
+
+	if len(patchList) > 0 {
+		return webhook.Patched("patched", patchList...)
+	}
+
+	return webhook.Allowed("skipped")
+}
+
+func getGlobalDefaultEgwPatch(ctx context.Context, cli client.Client) (*jsonpatch.JsonPatchOperation, error) {
+	egwList := &egressv1.EgressGatewayList{}
+	err := cli.List(ctx, egwList)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to check global default EgressGateway: %v", err)
+	}
+
+	var name string
+	for _, item := range egwList.Items {
+		if item.Spec.ClusterDefault {
+			name = item.Name
+		}
+	}
+	if name == "" {
+		return nil, nil
+	}
+
+	patch := &jsonpatch.JsonPatchOperation{
+		Operation: "add",
+		Path:      "/spec/egressGatewayName",
+		Value:     name,
+	}
+	return patch, nil
+}
+
+func mutateHookEgressClusterPolicy(ctx context.Context, req webhook.AdmissionRequest, cli client.Client) webhook.AdmissionResponse {
+	policy := new(egressv1.EgressClusterPolicy)
+	err := json.Unmarshal(req.Object.Raw, policy)
+	if err != nil {
+		return webhook.Denied(fmt.Sprintf("json unmarshal EgressPolicy with error: %v", err))
+	}
+
+	patchList := make([]jsonpatch.JsonPatchOperation, 0)
+
+	if policy.Spec.EgressGatewayName == "" {
+		p, err := getGlobalDefaultEgwPatch(ctx, cli)
+		if err != nil {
+			return webhook.Denied(err.Error())
+		}
+		if p != nil {
+			patchList = append(patchList, *p)
+		}
+	}
+
+	if policy.Spec.EgressIP.IsEmpty() {
+		patchList = append(patchList, jsonpatch.JsonPatchOperation{
+			Operation: "add",
+			Path:      "/spec/egressIP",
+			Value:     egressv1.EgressIP{UseNodeIP: false, AllocatorPolicy: "default"},
+		})
+	}
+
+	if len(patchList) > 0 {
+		return webhook.Patched("patched", patchList...)
+	}
+
+	return webhook.Allowed("skipped")
+}

--- a/pkg/egressgateway/egress_gateway_webhook.go
+++ b/pkg/egressgateway/egress_gateway_webhook.go
@@ -60,6 +60,15 @@ func (egw *EgressGatewayWebhook) EgressGatewayValidate(ctx context.Context, req 
 		return webhook.Denied(fmt.Sprintf("json unmarshal EgressGateway with error: %v", err))
 	}
 
+	if newEg.Spec.ClusterDefault {
+		egwList := new(egress.EgressGatewayList)
+		for _, item := range egwList.Items {
+			if item.Spec.ClusterDefault && item.Name != newEg.Name {
+				return webhook.Denied(fmt.Sprintf("A cluster can only have one default gateway, default gateway: %s.", item.Name))
+			}
+		}
+	}
+
 	// Checking the number of IPV4 and IPV6 addresses
 	var ipv4s, ipv6s []net.IP
 	ipv4Ranges, err := ip.MergeIPRanges(constant.IPv4, newEg.Spec.Ippools.IPv4)

--- a/pkg/k8s/apis/v1beta1/egressgateway_types.go
+++ b/pkg/k8s/apis/v1beta1/egressgateway_types.go
@@ -21,6 +21,7 @@ type EgressGatewayList struct {
 // +kubebuilder:resource:categories={egressgateway},path="egressgateways",singular="egressgateway",scope="Cluster",shortName={egw}
 // +kubebuilder:printcolumn:JSONPath=".spec.ippools.ipv4DefaultEIP",description="ipv4DefaultEIP",name="ipv4DefaultEIP",type=string
 // +kubebuilder:printcolumn:JSONPath=".spec.ippools.ipv6DefaultEIP",description="ipv6DefaultEIP",name="ipv6DefaultEIP",type=string
+// +kubebuilder:printcolumn:JSONPath=".spec.clusterDefault",description="clusterDefault",name="clusterDefault",type=boolean
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 type EgressGateway struct {
@@ -32,6 +33,8 @@ type EgressGateway struct {
 }
 
 type EgressGatewaySpec struct {
+	// +kubebuilder:validation:Optional
+	ClusterDefault bool `json:"clusterDefault,omitempty"`
 	// +kubebuilder:validation:Optional
 	Ippools Ippools `json:"ippools,omitempty"`
 	// +kubebuilder:validation:Required

--- a/pkg/k8s/apis/v1beta1/labels.go
+++ b/pkg/k8s/apis/v1beta1/labels.go
@@ -3,4 +3,7 @@
 
 package v1beta1
 
-const LabelPolicyName = "spidernet.io/policy-name"
+const (
+	LabelPolicyName                    = "spidernet.io/policy-name"
+	LabelNamespaceEgressGatewayDefault = "spidernet.io/egressgateway-default"
+)

--- a/test/doc/egressgateway_zh.md
+++ b/test/doc/egressgateway_zh.md
@@ -25,21 +25,22 @@
 # EgressGateway E2E 用例
 - 用例中，所有有关 `eip` 校验的内容，都包含了 tcp，udp 和 web socket
 
-| 用例编号   | 标题                                                                            | 优先级 | 冒烟    | 状态   | 其他  |
-|--------|-------------------------------------------------------------------------------|-----|-------|------|-----|
-| G00001 | 使用不合法的 `Ippools` 时，创建 EgressGateway 会失败                                       | p2  | false |      |     |
-| G00002 | 当 `NodeSelector` 为空时，创建 EgressGateway 会失败                                     | p2  | false |      |     |
-| G00003 | 当 `DefaultEIP` 不在 `Ippools` 范围内，创建 EgressGateway 会失败                          | p2  | false |      |     |
-| G00004 | 当 `Ippools.IPv4` 和 `Ippools.IPv6` 的数量不一致时，创建 EgressGateway 会失败                | p2  | false |      |     |
-| G00005 | 当 `DefaultEIP` 为空，创建 EgressGateway 时，此字段会从 `Ippools` 中随机分配一个 IP               | p2  | false |      |     |
-| G00006 | 当 `Ippools` 为单个 IP 时，创建 EgressGateway 成功，`EgressGatewayStatus` 检查通过           | p2  | false |      |     |
-| G00007 | 当 `Ippools` 是 `a-b` 格式的 IP 范围时，创建 EgressGateway 成功，`EgressGatewayStatus` 检查通过 | p2  | false |      |     |
-| G00008 | 当 `Ippools` 是 IP cidr 格式时，创建 EgressGateway 成功，`EgressGatewayStatus` 检查通过      | p2  | false |      |     |
-| G00009 | 向 `Ippools` 中添加 不合法的 IP 地址时，更新 EgressGateway 会失败                              | p2  | false |      |     |
-| G00010 | 从 `Ippools` 中删除 正在被使用的 IP 地址时，更新 EgressGateway 会失败                            | p2  | false |      |     |
-| G00011 | 向 `Ippools.IPv4` 和 `Ippools.IPv6` 添加不同数量的 IP 时，更新 EgressGateway 会失败           | p2  | false |      |     |
-| G00012 | 向 `Ippools.IPv4` 和 `Ippools.IPv6` 添加相同数量的 IP 时，更新 EgressGateway 会成功           | p2  | false |      |     |
-| G00013 | 向 `Ippools` 中添加合法的 IP 地址，更新 EgressGateway 成功                                  | p2  | false |      |     |
-| G00014 | 当 `NodeSelector` 被编辑后，`egressGatewayStatus` 会如预期更新正确                          | p2  | false |      |     |
-| G00015 | 当存在 Policy （包括命名空间级别和集群级别）正在使用 EgressGateway 时，删除 EgressGateway 会失败           | p2  | false |      |     |
-| G00016 | 当没有 Policy 使用 EgressGateway 时，删除 EgressGateway 成功                             | p2  | false |      |     |
+| 用例编号   | 标题                                                                                                     | 优先级 | 冒烟    | 状态 | 其他 |
+|--------|--------------------------------------------------------------------------------------------------------|-----|-------|----|----|
+| G00001 | 使用不合法的 `Ippools` 时，创建 EgressGateway 会失败                                                                | p2  | false |    |    |
+| G00002 | 当 `NodeSelector` 为空时，创建 EgressGateway 会失败                                                              | p2  | false |    |    |
+| G00003 | 当 `DefaultEIP` 不在 `Ippools` 范围内，创建 EgressGateway 会失败                                                   | p2  | false |    |    |
+| G00004 | 当 `Ippools.IPv4` 和 `Ippools.IPv6` 的数量不一致时，创建 EgressGateway 会失败                                         | p2  | false |    |    |
+| G00005 | 当 `DefaultEIP` 为空，创建 EgressGateway 时，此字段会从 `Ippools` 中随机分配一个 IP                                        | p2  | false |    |    |
+| G00006 | 当 `Ippools` 为单个 IP 时，创建 EgressGateway 成功，`EgressGatewayStatus` 检查通过                                    | p2  | false |    |    |
+| G00007 | 当 `Ippools` 是 `a-b` 格式的 IP 范围时，创建 EgressGateway 成功，`EgressGatewayStatus` 检查通过                          | p2  | false |    |    |
+| G00008 | 当 `Ippools` 是 IP cidr 格式时，创建 EgressGateway 成功，`EgressGatewayStatus` 检查通过                               | p2  | false |    |    |
+| G00009 | 向 `Ippools` 中添加 不合法的 IP 地址时，更新 EgressGateway 会失败                                                       | p2  | false |    |    |
+| G00010 | 从 `Ippools` 中删除 正在被使用的 IP 地址时，更新 EgressGateway 会失败                                                     | p2  | false |    |    |
+| G00011 | 向 `Ippools.IPv4` 和 `Ippools.IPv6` 添加不同数量的 IP 时，更新 EgressGateway 会失败                                    | p2  | false |    |    |
+| G00012 | 向 `Ippools.IPv4` 和 `Ippools.IPv6` 添加相同数量的 IP 时，更新 EgressGateway 会成功                                    | p2  | false |    |    |
+| G00013 | 向 `Ippools` 中添加合法的 IP 地址，更新 EgressGateway 成功                                                           | p2  | false |    |    |
+| G00014 | 当 `NodeSelector` 被编辑后，`egressGatewayStatus` 会如预期更新正确                                                   | p2  | false |    |    |
+| G00015 | 当存在 Policy （包括命名空间级别和集群级别）正在使用 EgressGateway 时，删除 EgressGateway 会失败                                    | p2  | false |    |    |
+| G00016 | 当没有 Policy 使用 EgressGateway 时，删除 EgressGateway 成功                                                      | p2  | false |    |    |
+| G00017 | 创建 `EgressCluster` 或者 `EgressClusterPolicy` 时使用未指定 `spec.egressGatewayName` 时，可以使用自动设置租户或者集群默认网关，并创建成功 | p2  | false |    |    |

--- a/test/e2e/egressgateway/default_egressgateway_test.go
+++ b/test/e2e/egressgateway/default_egressgateway_test.go
@@ -1,0 +1,148 @@
+// Copyright 2022 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package egressgateway_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	egressv1 "github.com/spidernet-io/egressgateway/pkg/k8s/apis/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Test default egress gateway", Label("DefaultEgressGateway", "G00017"), Ordered, func() {
+	var clusterDefaultEgw *egressv1.EgressGateway
+	var nsDefaultEgw *egressv1.EgressGateway
+	var policy1 *egressv1.EgressPolicy
+	var policy2 *egressv1.EgressPolicy
+
+	BeforeAll(func() {
+		ipPool := egressv1.Ippools{}
+		if enableV4 {
+			ipPool.IPv4 = []string{"10.99.0.1"}
+		}
+		if enableV6 {
+			ipPool.IPv6 = []string{"4c83:a33d:f5e5:d0b5:b76e:117c:ba98:7518"}
+		}
+		clusterDefaultEgw = &egressv1.EgressGateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster-default",
+			},
+			Spec: egressv1.EgressGatewaySpec{
+				ClusterDefault: true,
+				Ippools:        ipPool,
+				NodeSelector: egressv1.NodeSelector{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/hostname": "egressgateway-control-plane",
+						}}}},
+		}
+
+		nsDefaultEgw = clusterDefaultEgw.DeepCopy()
+		nsDefaultEgw.Name = "ns-default"
+		nsDefaultEgw.Spec.ClusterDefault = false
+		if enableV4 {
+			nsDefaultEgw.Spec.Ippools.IPv4 = []string{"10.99.0.2"}
+		}
+		if enableV6 {
+			nsDefaultEgw.Spec.Ippools.IPv6 = []string{"4c83:a11d:f5e5:d0b5:b76e:117c:ba98:7518"}
+		}
+
+		policy1 = &egressv1.EgressPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-default-egw-policy1",
+				Namespace: "default",
+			},
+			Spec: egressv1.EgressPolicySpec{
+				EgressIP: egressv1.EgressIP{},
+				AppliedTo: egressv1.AppliedTo{
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "mock-app"},
+					},
+				},
+				DestSubnet: []string{"10.6.0.92/32"},
+			},
+		}
+		policy2 = policy1.DeepCopy()
+		policy2.Name = "test-default-egw-policy2"
+	})
+
+	It("test cluster default egress gateway", func() {
+		// create global egress gateway
+		err := f.CreateResource(clusterDefaultEgw)
+		Expect(err).NotTo(HaveOccurred())
+
+		// create egress policy1
+		err = f.CreateResource(policy1)
+		Expect(err).NotTo(HaveOccurred())
+
+		// check policy1 is bind to cluster default
+		key := types.NamespacedName{Namespace: policy1.Namespace, Name: policy1.Name}
+		err = f.GetResource(key, policy1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(policy1.Spec.EgressGatewayName).To(Equal(clusterDefaultEgw.Name))
+	})
+
+	It("test namespace default egress gateway", func() {
+		ns, err := f.GetNamespace("default")
+		Expect(err).NotTo(HaveOccurred())
+
+		if ns.Labels == nil {
+			ns.Labels = make(map[string]string)
+		}
+		val, ok := ns.Labels[egressv1.LabelNamespaceEgressGatewayDefault]
+		if !ok || val != nsDefaultEgw.Name {
+			ns.Labels[egressv1.LabelNamespaceEgressGatewayDefault] = nsDefaultEgw.Name
+			err = f.UpdateResource(ns)
+			Expect(err).NotTo(HaveOccurred())
+		}
+		err = f.CreateResource(policy2)
+		Expect(err).NotTo(HaveOccurred())
+
+		// check policy2 is bind to namespace default
+		key := types.NamespacedName{Namespace: policy2.Namespace, Name: policy2.Name}
+		err = f.GetResource(key, policy2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(policy2.Spec.EgressGatewayName).To(Equal(nsDefaultEgw.Name))
+	})
+
+	AfterAll(func() {
+		key := types.NamespacedName{Namespace: policy2.Namespace, Name: policy2.Name}
+		err := f.GetResource(key, policy2)
+		if err == nil {
+			err = f.DeleteResource(policy2)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		key = types.NamespacedName{Namespace: policy1.Namespace, Name: policy1.Name}
+		err = f.GetResource(key, policy1)
+		if err == nil {
+			err = f.DeleteResource(policy1)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		key = types.NamespacedName{Name: nsDefaultEgw.Name}
+		err = f.GetResource(key, nsDefaultEgw)
+		if err == nil {
+			err = f.DeleteResource(nsDefaultEgw)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		key = types.NamespacedName{Name: clusterDefaultEgw.Name}
+		err = f.GetResource(key, clusterDefaultEgw)
+		if err == nil {
+			err = f.DeleteResource(clusterDefaultEgw)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		ns, err := f.GetNamespace("default")
+		Expect(err).NotTo(HaveOccurred())
+		_, ok := ns.Labels[egressv1.LabelNamespaceEgressGatewayDefault]
+		if ok {
+			delete(ns.Labels, egressv1.LabelNamespaceEgressGatewayDefault)
+			err = f.UpdateResource(ns)
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+})


### PR DESCRIPTION
# 默认网关设置

## 1. 租户级默认网关

为了设定租户级的默认网关，可以在 Namespace 上打上特定的标签 `spidernet.io/egressgateway-default` 设置默认网关的名称。

### 步骤：

1. 使用以下命令为命名空间设置默认网关标签：

```shell
kubectl label ns <namespace> spidernet.io/egressgateway-default=<egress-gateway-name>
```

其中，`<namespace>` 是目标命名空间，`<egress-gateway-name>` 是要设定为默认网关的 EgressGateway 的名称。

## 2. 集群级默认网关

在集群级别上，思考了 3 个方案，目前使用选项 1 实现。

### 选项 1：对 EgressGateway 增加 `spec.clusterDefault` 的 `bool` 类型字段

```diff
type EgressGatewaySpec struct {
+	// +kubebuilder:validation:Optional
+	ClusterDefault bool `json:"clusterDefault,omitempty"`
	// +kubebuilder:validation:Optional
	Ippools Ippools `json:"ippools,omitempty"`
	// +kubebuilder:validation:Required
	NodeSelector NodeSelector `json:"nodeSelector,omitempty"`
}
```

### 选项 2：使用 `default` 名称的 EgressGateway （备选）

将一个名为 `default` 的 EgressGateway 作为集群的默认网关。唯一性好。

### 选项 3：通过标签来设定集群默认网关 （备选）

通过给特定的 EgressGateway 打上标签 `spidernet.io/egressgateway-cluster-default=true`，来指定该 EgressGateway 为集群级别的默认网关。

#### 步骤：

1. 为目标 EgressGateway 打上标签 `spidernet.io/egressgateway-cluster-default=true`，例如：

```shell
kubectl label egressgateway <egress-gateway-name> spidernet.io/egressgateway-cluster-default=true
```

其中，`<egress-gateway-name>` 是要设定为集群默认网关的 EgressGateway 的名称。

