### PR TITLE
Reduce unnecessary routes

### DIFF
--- a/pkg/agent/route/route.go
+++ b/pkg/agent/route/route.go
@@ -36,13 +36,12 @@ func (r *RuleRoute) PurgeStaleRules(marks map[int]struct{}, baseMark string) err
 						return err
 					}
 				}
-				return nil
 			}
 		}
 		return nil
 	}
 
-	rules, err := netlink.RuleList(netlink.FAMILY_V4)
+	rules, err := netlink.RuleListFiltered(netlink.FAMILY_V4, nil, netlink.RT_FILTER_MARK)
 	if err != nil {
 		return err
 	}
@@ -50,7 +49,7 @@ func (r *RuleRoute) PurgeStaleRules(marks map[int]struct{}, baseMark string) err
 		return err
 	}
 
-	rules, err = netlink.RuleList(netlink.FAMILY_V6)
+	rules, err = netlink.RuleListFiltered(netlink.FAMILY_V6, nil, netlink.RT_FILTER_MARK)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## 背景
ref https://github.com/spidernet-io/egressgateway/issues/654

仅下发必要的路由，否则再用 1000 个节点时，会下发 1000 条路由，会占用不必要的主机资源。

## 效果
```log
0:	from all lookup local
5203:	from all fwmark 0x26005d90 lookup 637558160
32766:	from all lookup main
32767:	from all lookup default
```