### PR TITLE
optimize log output

### DIFF
--- a/pkg/agent/eip.go
+++ b/pkg/agent/eip.go
@@ -33,7 +33,7 @@ type eip struct {
 
 func (r *eip) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := r.log.WithValues("name", req.Name, "kind", "EgressGateway")
-	log.Info("reconcile")
+	log.V(1).Info("reconcile")
 
 	deleted := false
 	gateway := new(egressv1.EgressGateway)

--- a/pkg/agent/police.go
+++ b/pkg/agent/police.go
@@ -536,7 +536,7 @@ func buildNatStaticRule(base uint32) map[string][]iptables.Rule {
 }
 
 func (r *policeReconciler) reconcileClusterInfo(ctx context.Context, req reconcile.Request, log logr.Logger) (reconcile.Result, error) {
-	log = log.WithValues("name", req.Name)
+	log = log.V(1).WithValues("name", req.Name)
 	log.Info("reconciling")
 
 	info := new(egressv1.EgressClusterInfo)
@@ -698,7 +698,7 @@ func (r *policeReconciler) ensureClusterInfoIPSet() error {
 // - add/update/delete egress gateway
 //   - iptables/ipset
 func (r *policeReconciler) reconcileGateway(ctx context.Context, req reconcile.Request, log logr.Logger) (reconcile.Result, error) {
-	log.Info("reconciling")
+	log.V(1).Info("reconciling")
 	err := r.initApplyPolicy()
 	if err != nil {
 		return reconcile.Result{Requeue: true}, err
@@ -758,7 +758,7 @@ func buildMangleStaticRule(base uint32) map[string][]iptables.Rule {
 // - ipset
 func (r *policeReconciler) reconcilePolicy(ctx context.Context, req reconcile.Request, log logr.Logger) (reconcile.Result, error) {
 	log = log.WithValues("name", req.Name, "namespace", req.Namespace)
-	log.Info("reconciling")
+	log.V(1).Info("reconciling")
 
 	policy := new(egressv1.EgressPolicy)
 	deleted := false
@@ -820,7 +820,7 @@ func (r *policeReconciler) reconcilePolicy(ctx context.Context, req reconcile.Re
 // - ipset
 func (r *policeReconciler) reconcileClusterPolicy(ctx context.Context, req reconcile.Request, log logr.Logger) (reconcile.Result, error) {
 	log = log.WithValues("name", req.Name)
-	log.Info("reconciling")
+	log.V(1).Info("reconciling")
 
 	policy := new(egressv1.EgressClusterPolicy)
 	deleted := false

--- a/pkg/controller/cluster_endpoint_slice.go
+++ b/pkg/controller/cluster_endpoint_slice.go
@@ -42,7 +42,7 @@ func (r *endpointClusterReconciler) Reconcile(ctx context.Context, req reconcile
 		"kind", "EgressClusterEndpointSlice",
 	)
 
-	log.Info("reconcile")
+	log.V(1).Info("reconcile")
 	deleted := false
 	policy := new(v1beta1.EgressClusterPolicy)
 	err := r.client.Get(ctx, req.NamespacedName, policy)

--- a/pkg/controller/egress_policy.go
+++ b/pkg/controller/egress_policy.go
@@ -35,7 +35,7 @@ func (r *egpReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	}
 
 	log := r.log.WithValues("name", newReq.Name, "kind", kind)
-	log.Info("reconciling")
+	log.V(1).Info("reconciling")
 	switch kind {
 	case "EgressGateway":
 		return r.reconcileEGW(ctx, newReq, log)

--- a/pkg/controller/egress_tunnel.go
+++ b/pkg/controller/egress_tunnel.go
@@ -98,7 +98,7 @@ func (r *egReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 	})
 
 	log := r.log.WithValues("name", newReq.Name, "kind", kind)
-	log.Info("reconciling")
+	log.V(1).Info("reconciling")
 	switch kind {
 	case "EgressTunnel":
 		return r.reconcileEGN(ctx, newReq, log)

--- a/pkg/controller/endpoint_slice.go
+++ b/pkg/controller/endpoint_slice.go
@@ -44,7 +44,7 @@ func (r *endpointReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 		"name", req.Name,
 		"kind", "EgressPolicy")
 
-	log.Info("reconcile")
+	log.V(1).Info("reconcile")
 	deleted := false
 	policy := new(v1beta1.EgressPolicy)
 	err := r.client.Get(ctx, req.NamespacedName, policy)

--- a/pkg/egressgateway/egress_gateway.go
+++ b/pkg/egressgateway/egress_gateway.go
@@ -435,7 +435,7 @@ func (r egnReconciler) reconcileEGP(ctx context.Context, req reconcile.Request, 
 	} else {
 		log = log.WithValues("name", req.Name, "namespace", req.Namespace)
 	}
-	log.Info("reconciling")
+	log.V(1).Info("reconciling")
 
 	deleted := false
 	isUpdate := false


### PR DESCRIPTION
Fix https://github.com/spidernet-io/egressgateway/issues/656

controller:
* 这些信息是比较重要的，做一些合并，减少日志量；
*  周期日志问题：kubelet 的 Node 的更新事件触发的，调整了日志级别；

agent:
* 周期日志问题：这个是 agent 定期维护 policy 规则，防止保第三方用户误删，是 debug 级别的。