### PR TITLE
Add e2e case P00001 P00004 P00005 P00006 P00017

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-logr/logr v1.2.4
 	github.com/go-swagger/go-swagger v0.30.4
 	github.com/google/gops v0.3.27
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/mdlayher/arp v0.0.0-20220221190821-c37aaafac7f9
 	github.com/mdlayher/ethernet v0.0.0-20220221185849-529eae5b6118
@@ -80,7 +81,6 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/test/e2e/common/egp.go
+++ b/test/e2e/common/egp.go
@@ -133,7 +133,7 @@ func CreateEgressPolicyCustom(ctx context.Context, cli client.Client, setUp func
 
 	err := cli.Create(ctx, res)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error:\n%w\npolicy yaml:\n%s\n", err, GetObjYAML(res))
 	}
 	return res, nil
 }

--- a/test/e2e/egressgateway/egressgateway_test.go
+++ b/test/e2e/egressgateway/egressgateway_test.go
@@ -12,6 +12,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/google/uuid"
+
 	"github.com/go-faker/faker/v4"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -191,7 +193,7 @@ var _ = Describe("Operate EgressGateway", Label("EgressGateway"), Ordered, func(
 			nodeSelector := egressv1.NodeSelector{
 				Selector: nodeLabelSelector,
 			}
-			egw, err = common.CreateGatewayNew(ctx, cli, "egw-"+strings.ToLower(faker.FirstName())+faker.Word(), egressv1.Ippools{}, nodeSelector)
+			egw, err = common.CreateGatewayNew(ctx, cli, "egw-"+uuid.NewString(), egressv1.Ippools{}, nodeSelector)
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Printf("Succeeded to create egw:\n%s\n", common.GetObjYAML(egw))
 

--- a/test/e2e/egresspolicy/egresspolicy_test.go
+++ b/test/e2e/egresspolicy/egresspolicy_test.go
@@ -5,10 +5,13 @@ package egresspolicy_test
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/google/uuid"
 
 	"github.com/go-faker/faker/v4"
 	appsv1 "k8s.io/api/apps/v1"
@@ -29,7 +32,7 @@ var _ = Describe("EgressPolicy", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 		nodeSelector := egressv1.NodeSelector{Selector: &metav1.LabelSelector{MatchLabels: nodeLabel}}
 
-		egw, err = common.CreateGatewayNew(ctx, cli, "egw-"+faker.Word(), pool, nodeSelector)
+		egw, err = common.CreateGatewayNew(ctx, cli, "egw-"+uuid.NewString(), pool, nodeSelector)
 		Expect(err).NotTo(HaveOccurred())
 		GinkgoWriter.Printf("Create EgressGateway: %s\n", egw.Name)
 
@@ -204,5 +207,146 @@ var _ = Describe("EgressPolicy", Ordered, func() {
 			err = common.CheckDaemonSetEgressIP(ctx, cli, config, egressConfig, dsB, e.Ipv4, e.Ipv6, false)
 			Expect(err).NotTo(HaveOccurred())
 		})
+	})
+
+	/*
+		These test cases mainly test some limiting checks when creating policies and cluster-policies to see if they meet expectations. It mainly includes the following checks:
+
+		1. Using an illegal egressIP to create a policy will fail.
+		2. When the manually specified egressIP of the policy is not in the IP pool range of the gateway used by this policy, the creation will fail.
+		3. When Spec.AppliedTo of the policy is empty, the creation will fail.
+		4. When the policy specifies both Spec.AppliedTo.PodSubnet and Spec.AppliedTo.PodSelector at the same time, the creation will fail.
+		5. When Spec.EgressIP.UseNodeIP of the policy is true, but an egressIP is also specified at the same time, the creation will fail.
+	*/
+	Context("Creation test", func() {
+		ctx := context.Background()
+		var egp *egressv1.EgressPolicy
+		var egcp *egressv1.EgressClusterPolicy
+		var err error
+
+		AfterEach(func() {
+			// delete the policy if it is exist
+			if egp != nil {
+				err = common.WaitEgressPoliciesDeleted(ctx, cli, []*egressv1.EgressPolicy{egp}, time.Second*5)
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
+		DescribeTable("namespaced policy", func(expectErr bool, setUp func(egp *egressv1.EgressPolicy)) {
+			egp, err = common.CreateEgressPolicyCustom(ctx, cli, setUp)
+			if expectErr {
+				Expect(err).To(HaveOccurred(), fmt.Sprintf("egressPolicy yaml:\n%s\n", common.GetObjYAML(egp)))
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+			// todo @bzsuni waiting for the bug be fixed
+			PEntry("should fail when the policy is set with invalid `EgressIP`", Label("P00001"), true, func(egp *egressv1.EgressPolicy) {
+				egp.Spec.EgressGatewayName = egw.Name
+				egp.Spec.AppliedTo.PodSubnet = []string{"10.10.0.0/16"}
+				if egressConfig.EnableIPv4 {
+					egp.Spec.EgressIP.IPv4 = "fddd:10::2"
+				}
+				if egressConfig.EnableIPv6 {
+					egp.Spec.EgressIP.IPv6 = "10.10.10.2"
+				}
+			}),
+			// todo @bzsuni waiting for the bug be fixed
+			PEntry("should fail when the `Spec.EgressIP` of the policy is not within the IP range of the ippools in the gateway used by the policy", Label("P00004"), true,
+				func(egp *egressv1.EgressPolicy) {
+					egp.Spec.EgressGatewayName = egw.Name
+					egp.Spec.AppliedTo.PodSubnet = []string{"10.10.0.0/16"}
+					if egressConfig.EnableIPv4 {
+						egp.Spec.EgressIP.IPv4 = "10.10.10.2"
+					}
+					if egressConfig.EnableIPv6 {
+						egp.Spec.EgressIP.IPv6 = "fddd:10::2"
+					}
+				}),
+			// todo @bzsuni waiting for the bug be fixed
+			PEntry("should fail when Spec.AppliedTo is empty", Label("P00005"), true,
+				func(egp *egressv1.EgressPolicy) {
+					egp.Spec.EgressGatewayName = egw.Name
+					egp.Spec.AppliedTo = egressv1.AppliedTo{}
+				}),
+			Entry("should fail when the policy set with both Spec.AppliedTo.PodSubnet and Spec.AppliedTo.PodSelector", Label("P00006"), true,
+				func(egp *egressv1.EgressPolicy) {
+					egp.Spec.EgressGatewayName = egw.Name
+					egp.Spec.AppliedTo.PodSubnet = []string{"10.10.0.0/16"}
+					egp.Spec.AppliedTo.PodSelector = &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}}
+				}),
+			Entry("should fail when the `Spec.EgressIP.UseNodeIP` of the policy is set to true and the Spec.EgressIP is not empty", Label("P00017"), true,
+				func(egp *egressv1.EgressPolicy) {
+					egp.Spec.EgressGatewayName = egw.Name
+					egp.Spec.AppliedTo.PodSubnet = []string{"10.10.0.0/16"}
+					egp.Spec.EgressIP.UseNodeIP = true
+					if egressConfig.EnableIPv4 {
+						egp.Spec.EgressIP.IPv4 = egw.Spec.Ippools.Ipv4DefaultEIP
+					}
+					if egressConfig.EnableIPv6 {
+						egp.Spec.EgressIP.IPv6 = egw.Spec.Ippools.Ipv6DefaultEIP
+					}
+				}),
+		)
+
+		DescribeTable("cluster policy", func(expectErr bool, setUp func(egp *egressv1.EgressClusterPolicy)) {
+			egcp, err = common.CreateEgressClusterPolicyCustom(ctx, cli, setUp)
+			if expectErr {
+				Expect(err).To(HaveOccurred(), fmt.Sprintf("egressClusterPolicy yaml:\n%s\n", common.GetObjYAML(egcp)))
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+			// todo @bzsuni waiting for the bug be fixed
+			PEntry("should fail when the cluster-policy is set with invalid `EgressIP`", Label("P00001"), true, func(egcp *egressv1.EgressClusterPolicy) {
+				egcp.Spec.EgressGatewayName = egw.Name
+				egcp.Spec.AppliedTo.PodSubnet = &[]string{"10.10.0.0/16"}
+				if egressConfig.EnableIPv4 {
+					egcp.Spec.EgressIP.IPv4 = "fddd:10::2"
+				}
+				if egressConfig.EnableIPv6 {
+					egcp.Spec.EgressIP.IPv6 = "10.10.10.2"
+				}
+			}),
+			// todo @bzsuni waiting for the bug be fixed
+			PEntry("should fail when the `Spec.EgressIP` of the cluster-policy is not within the IP range of the ippools in the gateway used by the policy", Label("P00004"), true,
+				func(egcp *egressv1.EgressClusterPolicy) {
+					egcp.Spec.EgressGatewayName = egw.Name
+					egcp.Spec.AppliedTo.PodSubnet = &[]string{"10.10.0.0/16"}
+					if egressConfig.EnableIPv4 {
+						egcp.Spec.EgressIP.IPv4 = "10.10.10.2"
+					}
+					if egressConfig.EnableIPv6 {
+						egcp.Spec.EgressIP.IPv6 = "fddd:10::2"
+					}
+				}),
+
+			// todo @bzsuni waiting for the bug be fixed
+			PEntry("should fail when Spec.AppliedTo is empty", Label("P00005"), true,
+				func(egcp *egressv1.EgressClusterPolicy) {
+					egcp.Spec.EgressGatewayName = egw.Name
+					egcp.Spec.AppliedTo = egressv1.ClusterAppliedTo{}
+				}),
+			// todo @bzsuni waiting for the bug be fixed
+			PEntry("should fail when the cluster-policy set with both Spec.AppliedTo.PodSubnet and Spec.AppliedTo.PodSelector", Label("P00006"), true,
+				func(egcp *egressv1.EgressClusterPolicy) {
+					egcp.Spec.EgressGatewayName = egw.Name
+					egcp.Spec.AppliedTo.PodSubnet = &[]string{"10.10.0.0/16"}
+					egcp.Spec.AppliedTo.PodSelector = &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}}
+				}),
+			// todo @bzsuni waiting for the bug be fixed
+			PEntry("should fail when the `Spec.EgressIP.UseNodeIP` of the cluster-policy is set to true and the Spec.EgressIP is not empty", Label("P00017"), true,
+				func(egcp *egressv1.EgressClusterPolicy) {
+					egcp.Spec.EgressGatewayName = egw.Name
+					egcp.Spec.AppliedTo.PodSubnet = &[]string{"10.10.0.0/16"}
+					egcp.Spec.EgressIP.UseNodeIP = true
+					if egressConfig.EnableIPv4 {
+						egcp.Spec.EgressIP.IPv4 = egw.Spec.Ippools.Ipv4DefaultEIP
+					}
+					if egressConfig.EnableIPv6 {
+						egcp.Spec.EgressIP.IPv6 = egw.Spec.Ippools.Ipv6DefaultEIP
+					}
+				}),
+		)
 	})
 })


### PR DESCRIPTION
添加 e2e 用例： P00001 P00004 P00005 P00006 P00017

这些用例主要是测试创建 policy 和 cluster-policy 时的一些限定校验是否符合预期，主要包含了如下校验：
 1. 使用不合法的 egressIP 创建 policy 会失败
 2. 当手动指定的 policy 的 egressIP 没有在这个 policy 所使用的 gateway 的 IP 池范围内时，会创建失败
 3. 当 policy 的 Spec.AppliedTo 为空时 会创建失败
 4. 当 policy 同时指定了 Spec.AppliedTo.PodSubnet 和 Spec.AppliedTo.PodSelector 时，会创建失败
 5. 当 policy 的 Spec.EgressIP.UseNodeIP 为 true，但是同时又指定了 egressIP 时，会创建失败
 

