### PR TITLE
Add a retry when deleting the egressgateway

### DIFF
--- a/test/e2e/egressgateway/egressgateway_test.go
+++ b/test/e2e/egressgateway/egressgateway_test.go
@@ -67,13 +67,13 @@ var _ = Describe("Operate EgressGateway", Label("EgressGateway"), Ordered, func(
 
 			GinkgoWriter.Printf("singleIpv4Pool: %s, singleIpv6Pool: %s\n", singleIpv4Pool, singleIpv6Pool)
 
-			// DeferCleanup(func() {
-			// 	// delete EgressGateway
-			// 	if egw != nil {
-			// 		err := common.DeleteObj(ctx, cli, egw)
-			// 		Expect(err).NotTo(HaveOccurred())
-			// 	}
-			// })
+			DeferCleanup(func() {
+				// delete EgressGateway
+				if egw != nil {
+					err := common.WaitEgressGatewayDeleted(ctx, cli, egw, time.Second*5)
+					Expect(err).NotTo(HaveOccurred())
+				}
+			})
 		})
 
 		/*
@@ -216,7 +216,7 @@ var _ = Describe("Operate EgressGateway", Label("EgressGateway"), Ordered, func(
 				// delete egw
 				if egw != nil {
 					GinkgoWriter.Printf("Delete egw: %s\n", egw.Name)
-					Expect(common.DeleteObj(ctx, cli, egw)).NotTo(HaveOccurred())
+					Expect(common.WaitEgressGatewayDeleted(ctx, cli, egw, time.Second*5)).NotTo(HaveOccurred())
 				}
 			})
 		})
@@ -349,7 +349,7 @@ var _ = Describe("Operate EgressGateway", Label("EgressGateway"), Ordered, func(
 			DeferCleanup(func() {
 				// delete EgressGateway
 				if egw != nil {
-					err := common.DeleteObj(ctx, cli, egw)
+					err := common.WaitEgressGatewayDeleted(ctx, cli, egw, time.Second*5)
 					Expect(err).NotTo(HaveOccurred())
 				}
 			})


### PR DESCRIPTION
在现有用例代码中，删除 gateway 时，只确保了引用此 gateway 的 policies 都被删除后，就马上删除 gateway。
而删除 policies 后，gateway 中有关 policies 的 status 会有一个同步更新的过程。
当 gateway status 还没有更新完成，此时就进行了删除，就会导致报错：
```
admission webhook "egressgateway.egressgateway.spidernet.io" denied the request: Do not delete :egw-amyaet because it is already referenced by EgressPolicy
```


此 pr 增加了 gateway 删除重试
相关issue: #864