### PR TITLE
Fix panic due to nil spec.appliedTo.podSelector in policy

### DIFF
--- a/pkg/controller/webhook/validate.go
+++ b/pkg/controller/webhook/validate.go
@@ -61,7 +61,8 @@ func ValidateHook(client client.Client, cfg *config.Config) *webhook.Admission {
 					}
 				}
 
-				if len(egcp.Spec.AppliedTo.PodSelector.MatchLabels) != 0 && len(*egcp.Spec.AppliedTo.PodSubnet) != 0 {
+				if (egcp.Spec.AppliedTo.PodSelector != nil && len(egcp.Spec.AppliedTo.PodSelector.MatchLabels) != 0) &&
+					(egcp.Spec.AppliedTo.PodSubnet != nil && len(*egcp.Spec.AppliedTo.PodSubnet) != 0) {
 					return webhook.Denied("podSelector and podSubnet cannot be used together")
 				}
 
@@ -130,7 +131,7 @@ func ValidateHook(client client.Client, cfg *config.Config) *webhook.Admission {
 					}
 				}
 
-				if len(egp.Spec.AppliedTo.PodSelector.MatchLabels) != 0 && len(egp.Spec.AppliedTo.PodSubnet) != 0 {
+				if egp.Spec.AppliedTo.PodSelector != nil && len(egp.Spec.AppliedTo.PodSelector.MatchLabels) != 0 && len(egp.Spec.AppliedTo.PodSubnet) != 0 {
 					return webhook.Denied("podSelector and podSubnet cannot be used together")
 				}
 

--- a/test/e2e/common/eci.go
+++ b/test/e2e/common/eci.go
@@ -87,6 +87,9 @@ func CheckEgressClusterInfoStatusSynced(
 				if err != nil {
 					return err
 				}
+				if eci.Status.ClusterIP == nil {
+					return fmt.Errorf("error: empty  eci.Status.ClusterIP")
+				}
 				err1 := diffTwoSlice(eci.Status.ClusterIP.IPv4, clusterIPv4CIDRs)
 				err2 := diffTwoSlice(eci.Status.ClusterIP.IPv6, clusterIPv6CIDRs)
 				if err1 == nil && err2 == nil {


### PR DESCRIPTION
修复 由于 Spec.AppliedTo.PodSelector 为 nil 时，创建 policy ， controller panic
相关issue: #868