### PR TITLE
add e2e case P00015 and P00016

### DIFF
--- a/test/e2e/egressgateway/egressgateway_test.go
+++ b/test/e2e/egressgateway/egressgateway_test.go
@@ -217,6 +217,7 @@ var _ = Describe("Operate EgressGateway", Label("EgressGateway"), Ordered, func(
 
 				// delete egw
 				if egw != nil {
+					time.Sleep(time.Second * 3)
 					GinkgoWriter.Printf("Delete egw: %s\n", egw.Name)
 					Expect(common.DeleteObj(ctx, cli, egw)).NotTo(HaveOccurred())
 				}

--- a/test/e2e/egresspolicy/egresspolicy_suite_test.go
+++ b/test/e2e/egresspolicy/egresspolicy_suite_test.go
@@ -32,6 +32,8 @@ var (
 	cli client.Client
 
 	nodeLabel map[string]string
+
+	node1, node2 *corev1.Node
 )
 
 var _ = BeforeSuite(func() {
@@ -54,6 +56,8 @@ var _ = BeforeSuite(func() {
 
 	//
 	nodeLabel = nodes.Items[0].Labels
+	node1 = &nodes.Items[0]
+	node2 = &nodes.Items[1]
 
 	// get egressgateway config
 	configMap := &corev1.ConfigMap{}

--- a/test/e2e/reliability/reliability_ip_test.go
+++ b/test/e2e/reliability/reliability_ip_test.go
@@ -69,7 +69,7 @@ var _ = Describe("IP Allocation", Label("Reliability_IP"), func() {
 	// (9) Delete all policies (start timing).
 	// (10) Verify that the gateway status has synchronized successfully, and all IPs have been released (after deletion is complete, calculate the time spent).
 	// (11) Check pod egress IPs again; they should no longer match the previous EIPs.
-	PIt("test IP allocation", Label("R00008"), Serial, func() {
+	PIt("test IP allocation", Label("R00008", "P00009"), Serial, func() {
 		// create egresspolicies
 		By("create egressPolicies by gaven pods")
 		egps, _, err = common.CreateEgressPoliciesForPods(ctx, cli, egw, pods, egressConfig.EnableIPv4, egressConfig.EnableIPv6, time.Second*5)


### PR DESCRIPTION
添加 e2e 用例 P00015 P00016

此用例测试在创建policy时,EgressIP.UseNodeIP设置为true的情况下,更新gateway后的一些校验。用例步骤如下:

1. 创建gateway,指定nodeSelector为node1
2. 创建policy,设置EgressIP.UseNodeIP为true
3. 校验gateway和policy状态,校验pod的出口ip应该为node1的IP
4. 更新gateway,使其从匹配node1更新为匹配node2
5. 校验gateway和policy状态,校验pod的出口ip应该为node2的IP
