### PR TITLE
Add case P00021

### DIFF
--- a/test/e2e/common/pod.go
+++ b/test/e2e/common/pod.go
@@ -67,6 +67,34 @@ func CreatePod(ctx context.Context, cli client.Client, image string) (*corev1.Po
 	}
 }
 
+func CreatePodCustom(ctx context.Context, cli client.Client, name, image string, setUp func(pod *corev1.Pod)) (*corev1.Pod, error) {
+	var terminationGracePeriodSeconds int64 = 0
+
+	res := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: corev1.PodSpec{
+			TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
+			Containers: []corev1.Container{
+				{
+					Name:            name,
+					Image:           image,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"/bin/sh", "-c", "sleep infinity"},
+				},
+			},
+		}}
+
+	setUp(res)
+
+	err := cli.Create(ctx, res)
+	if err != nil {
+		return nil, fmt.Errorf("error:\n%w\npod yaml:\n%s\n", err, GetObjYAML(res))
+	}
+	return res, nil
+}
+
 // CreatePods create pods by gaven number "n"
 func CreatePods(ctx context.Context, cli client.Client, img string, n int) []*corev1.Pod {
 	var res []*corev1.Pod
@@ -79,4 +107,33 @@ func CreatePods(ctx context.Context, cli client.Client, img string, n int) []*co
 		i++
 	}
 	return res
+}
+
+func WaitPodRunning(ctx context.Context, cli client.Client, pod *corev1.Pod, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var e error
+
+	for {
+		select {
+		case <-ctx.Done():
+			if e != nil {
+				return fmt.Errorf("timeout to wait the pod running, error: %v", e)
+			}
+			return fmt.Errorf("timeout to wait the pod running")
+
+		default:
+			err := cli.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, pod)
+			if err != nil {
+				e = err
+				time.Sleep(time.Second)
+				continue
+			}
+			if pod.Status.Phase == corev1.PodRunning {
+				return nil
+			}
+			time.Sleep(time.Second)
+		}
+	}
 }


### PR DESCRIPTION
命名空间级别的 policy 作用域 只作在 其指定的 namespace 中生效
1. 创建 ns test-ns
2. 在 default， test-ns 命名空间中分别创建同名 pod
3. 在 default 命名空间 创建 policy， PodSelector 对应以上 pod 的 label
4. 检测 default 命名空间中的 pod 出口 IP 应该为 policy 的 eip
5. 检测 test-ns 命名空间中的 pod 出口 IP 不应为 policy 的 eip