### PR TITLE
Update chart-testing-action to v2.6.0

### DIFF
--- a/.github/workflows/call-lint-chart.yaml
+++ b/.github/workflows/call-lint-chart.yaml
@@ -84,7 +84,7 @@ jobs:
       # Pre-requisites: A GitHub repo containing a directory with your Helm charts (e.g: charts)
       - name: Set up chart-testing
         if: ${{ env.RUN_JUST_LINT_CHART == 'false' }}
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Run chart-testing (list-changed)
         if: ${{ env.RUN_JUST_LINT_CHART == 'false' }}


### PR DESCRIPTION
Fix https://github.com/spidernet-io/egressgateway/issues/907

Ref https://github.com/helm/chart-testing-action/issues/132

是 100% 失败，需要升级版本