### PR TITLE
Optimize the code for checking whether Calico exists

### DIFF
--- a/pkg/controller/egress_cluster_info/egress_cluster_info_internal_test.go
+++ b/pkg/controller/egress_cluster_info/egress_cluster_info_internal_test.go
@@ -228,7 +228,7 @@ var _ = Describe("EgressClusterInfo", Serial, Label("EgressClusterInfo UT"), fun
 			// when egci.Spec.AutoDetect.NodeIP is true
 			egci.Spec.AutoDetect.NodeIP = true
 			// when isWatchingNode is true
-			r.isWatchingNode = true
+			r.isWatchingNode.Store(true)
 
 			// set client
 			objs = append(objs, egci)
@@ -258,7 +258,7 @@ var _ = Describe("EgressClusterInfo", Serial, Label("EgressClusterInfo UT"), fun
 				egci.Spec.AutoDetect.PodCidrMode = egressv1beta1.CniTypeCalico
 
 				// set eciReconciler
-				r.isWatchingCalico = true
+				r.isWatchingCalico.Store(true)
 				objs = append(objs, egci)
 				builder.WithObjects(objs...)
 				builder.WithStatusSubresource(objs...)
@@ -422,14 +422,7 @@ var _ = Describe("EgressClusterInfo", Serial, Label("EgressClusterInfo UT"), fun
 			_, _ = r.listCalicoIPPools(ctx)
 
 			// test method stopCheckCalico
-			r.isCheckCalicoGoroutineRunning.Store(true)
-			r.stopCheckChan = make(chan struct{})
 			r.stopCheckCalico()
-
-			// test method stopAllCheckGoroutine
-			r.taskToken.Store(true)
-			r.stopCheckChan = make(chan struct{})
-			r.stopAllCheckGoroutine()
 
 		})
 


### PR DESCRIPTION
简化 检测 calico 是否存在的逻辑，优化代码
之前根据 channel 来决定是否需要关闭 检测 calico 是否存在的协程
目前改为 通过 原子变量 的方式判断
修复：#851