### PR TITLE
Fix the policy's status check in the function  in the e2e test

### DIFF
--- a/test/e2e/common/egp.go
+++ b/test/e2e/common/egp.go
@@ -291,7 +291,7 @@ func WaitEgressPolicyStatusReady(ctx context.Context, cli client.Client, egp *eg
 				time.Sleep(time.Second / 2)
 				continue
 			}
-			if egp.Spec.EgressIP.UseNodeIP {
+			if !egp.Spec.EgressIP.UseNodeIP {
 				if v4Enabled && len(egp.Status.Eip.Ipv4) != 0 {
 					v4Ok = true
 				}


### PR DESCRIPTION
修复 test/e2e/common/egp.go 中 WaitEgressPolicyStatusReady 判断 policy status 的 bug