### PR TITLE
Verify that the EIP within the IP address ranges configured in the ippools of the egressgateway

### DIFF
--- a/pkg/controller/webhook/validate_test.go
+++ b/pkg/controller/webhook/validate_test.go
@@ -235,6 +235,67 @@ func TestValidateEgressPolicy(t *testing.T) {
 			},
 			expAllow: false,
 		},
+		"case7 the policy's eip is not within the ip ranges defined in the ippool of the gateway": {
+			existingResources: []client.Object{
+				&v1beta1.EgressGateway{
+					ObjectMeta: metav1.ObjectMeta{Name: "test"},
+					Spec: v1beta1.EgressGatewaySpec{
+						Ippools: v1beta1.Ippools{
+							IPv4: []string{"172.18.1.2-172.18.1.5"},
+							IPv6: []string{"fc00:f853:ccd:e793:a::3-fc00:f853:ccd:e793:a::6"},
+						},
+					},
+				},
+			},
+			spec: v1beta1.EgressPolicySpec{
+				EgressGatewayName: "test",
+				EgressIP: v1beta1.EgressIP{
+					UseNodeIP: false,
+					IPv4:      "172.19.1.2",
+					IPv6:      "fddd:feee::2",
+				},
+				AppliedTo: v1beta1.AppliedTo{
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+				},
+				DestSubnet: []string{
+					"192.168.1.1/24",
+					"1.1.1.1/32",
+					"10.0.6.1/16",
+					"fd00::21/112",
+				},
+			},
+			expAllow: false,
+		},
+		"case8 reating a policy with the value of the field spec.egressIP.useNodeIP set to false when the ippool of its referenced gateway is empty": {
+			existingResources: []client.Object{
+				&v1beta1.EgressGateway{
+					ObjectMeta: metav1.ObjectMeta{Name: "test"},
+					Spec: v1beta1.EgressGatewaySpec{
+						Ippools: v1beta1.Ippools{},
+					},
+				},
+			},
+			spec: v1beta1.EgressPolicySpec{
+				EgressGatewayName: "test",
+				EgressIP: v1beta1.EgressIP{
+					UseNodeIP: false,
+				},
+				AppliedTo: v1beta1.AppliedTo{
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+				},
+				DestSubnet: []string{
+					"192.168.1.1/24",
+					"1.1.1.1/32",
+					"10.0.6.1/16",
+					"fd00::21/112",
+				},
+			},
+			expAllow: false,
+		},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -656,6 +717,39 @@ func TestValidateEgressClusterPolicy(t *testing.T) {
 				EgressGatewayName: "test",
 				AppliedTo:         v1beta1.ClusterAppliedTo{},
 				DestSubnet:        []string{},
+			},
+			expAllow: false,
+		},
+		"case6 the policy's eip is not within the ip ranges defined in the ippool of the gateway": {
+			existingResources: []client.Object{
+				&v1beta1.EgressGateway{
+					ObjectMeta: metav1.ObjectMeta{Name: "test"},
+					Spec: v1beta1.EgressGatewaySpec{
+						Ippools: v1beta1.Ippools{
+							IPv4: []string{"172.18.1.2-172.18.1.5"},
+							IPv6: []string{"fc00:f853:ccd:e793:a::3-fc00:f853:ccd:e793:a::6"},
+						},
+					},
+				},
+			},
+			spec: v1beta1.EgressClusterPolicySpec{
+				EgressGatewayName: "test",
+				EgressIP: v1beta1.EgressIP{
+					UseNodeIP: false,
+					IPv4:      "10.10.10.1",
+					IPv6:      "fddd:10::1",
+				},
+				AppliedTo: v1beta1.ClusterAppliedTo{
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+				},
+				DestSubnet: []string{
+					"192.168.1.1/24",
+					"1.1.1.1/32",
+					"10.0.6.1/16",
+					"fd00::21/112",
+				},
 			},
 			expAllow: false,
 		},

--- a/pkg/egressgateway/egress_gateway.go
+++ b/pkg/egressgateway/egress_gateway.go
@@ -940,7 +940,7 @@ func (r egnReconciler) allocatorEIP(selEipLolicy string, nodeName string, pi pol
 	var perIpv6 string
 	rander := rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	if r.config.FileConfig.EnableIPv4 {
+	if len(egw.Spec.Ippools.IPv4) > 0 {
 		var useIpv4s []net.IP
 
 		ipv4Ranges, _ := ip.MergeIPRanges(constant.IPv4, egw.Spec.Ippools.IPv4)
@@ -991,7 +991,7 @@ func (r egnReconciler) allocatorEIP(selEipLolicy string, nodeName string, pi pol
 		}
 	}
 
-	if r.config.FileConfig.EnableIPv6 {
+	if len(egw.Spec.Ippools.IPv6) > 0 {
 		if len(perIpv4) != 0 && len(GetEipByIPV4(perIpv4, egw).IPv6) != 0 {
 			return perIpv4, GetEipByIPV4(perIpv4, egw).IPv6, nil
 		}

--- a/test/e2e/egresspolicy/egresspolicy_test.go
+++ b/test/e2e/egresspolicy/egresspolicy_test.go
@@ -255,8 +255,7 @@ var _ = Describe("EgressPolicy", Ordered, func() {
 					egp.Spec.EgressIP.IPv6 = "10.10.10.2"
 				}
 			}),
-			// todo @bzsuni waiting for the bug be fixed
-			PEntry("should fail when the `Spec.EgressIP` of the policy is not within the IP range of the ippools in the gateway used by the policy", Label("P00004"), true,
+			Entry("should fail when the `Spec.EgressIP` of the policy is not within the IP range of the ippools in the gateway used by the policy", Label("P00004"), true,
 				func(egp *egressv1.EgressPolicy) {
 					egp.Spec.EgressGatewayName = egw.Name
 					egp.Spec.AppliedTo.PodSubnet = []string{"10.10.0.0/16"}
@@ -310,8 +309,7 @@ var _ = Describe("EgressPolicy", Ordered, func() {
 					egcp.Spec.EgressIP.IPv6 = "10.10.10.2"
 				}
 			}),
-			// todo @bzsuni waiting for the bug be fixed
-			PEntry("should fail when the `Spec.EgressIP` of the cluster-policy is not within the IP range of the ippools in the gateway used by the policy", Label("P00004"), true,
+			Entry("should fail when the `Spec.EgressIP` of the cluster-policy is not within the IP range of the ippools in the gateway used by the policy", Label("P00004"), true,
 				func(egcp *egressv1.EgressClusterPolicy) {
 					egcp.Spec.EgressGatewayName = egw.Name
 					egcp.Spec.AppliedTo.PodSubnet = &[]string{"10.10.0.0/16"}


### PR DESCRIPTION
Fix: #871 
Fix: #1017

This pr fixed the two issues below:
1. Verify that the Egress IP (EIP) falls within the IP address range configured in the IP pools of the Egress Gateway when creating the Egress Policy.
2. Allow the creation of a single IPv4 or IPv6 IP pool when the Egress Gateway ConfigMap is set to dual mode.