### PR TITLE
sync node status to egt

### DIFF
--- a/charts/crds/egressgateway.spidernet.io_egresstunnels.yaml
+++ b/charts/crds/egressgateway.spidernet.io_egresstunnels.yaml
@@ -72,6 +72,7 @@ spec:
                 - Failed
                 - Ready
                 - HeartbeatTimeout
+                - NodeNotReady
                 type: string
               tunnel:
                 properties:

--- a/docs/reference/EgressTunnel.en.md
+++ b/docs/reference/EgressTunnel.en.md
@@ -29,4 +29,6 @@ status:
     - `Init`: successful tunnel IP allocation
     - `Ready`: the tunnel IP is allocated and tunnel is established
     - `Failed`: tunnel IP allocation fails
+    - `HeartbeatTimeout` heartbeat Timeout for Agent
+    - `NodeNotReady` Node Status is NotReady
 8. Packet mark value, one for each node. For example, if node A has egress traffic that needs to be forwarded to gateway node B, the traffic of node A will be marked with a mark.Each node is assigned a unique packet mark value. For instance, if Node A needs to forward Egress traffic to the gateway node B, it applies a specific mark to the packets originating from Node A.

--- a/docs/reference/EgressTunnel.zh.md
+++ b/docs/reference/EgressTunnel.zh.md
@@ -29,4 +29,6 @@ status:
     - `Init`：分配隧道 IP 成功
     - `Ready`：隧道 IP 已分配，且隧道已建成
     - `Failed`：隧道 IP 分配失败
+    - `HeartbeatTimeout` Agent 心跳超时
+    - `NodeNotReady` Node 状态处于 NotReady
 8. 数据包 mark 值，每个节点对应一个。例如节点 A 有 Egress 流量需要转发到网关节点 B，会对 A 节点的流量打 mark 进行标记。

--- a/pkg/k8s/apis/v1beta1/egresstunnel_types.go
+++ b/pkg/k8s/apis/v1beta1/egresstunnel_types.go
@@ -38,7 +38,7 @@ type EgressTunnelSpec struct{}
 type EgressTunnelStatus struct {
 	// +kubebuilder:validation:Optional
 	Tunnel Tunnel `json:"tunnel,omitempty"`
-	// +kubebuilder:validation:Enum=Pending;Init;Failed;Ready;HeartbeatTimeout
+	// +kubebuilder:validation:Enum=Pending;Init;Failed;Ready;HeartbeatTimeout;NodeNotReady
 	Phase EgressTunnelPhase `json:"phase,omitempty"`
 	// +kubebuilder:validation:Optional
 	Mark string `json:"mark,omitempty"`
@@ -77,6 +77,8 @@ const (
 	EgressTunnelFailed EgressTunnelPhase = "Failed"
 	// EgressTunnelHeartbeatTimeout tunnel heartbeat timeout
 	EgressTunnelHeartbeatTimeout EgressTunnelPhase = "HeartbeatTimeout"
+	// EgressTunnelNodeNotReady node not ready
+	EgressTunnelNodeNotReady EgressTunnelPhase = "NodeNotReady"
 	// EgressTunnelReady tunnel is available
 	EgressTunnelReady EgressTunnelPhase = "Ready"
 )


### PR DESCRIPTION
Fix https://github.com/spidernet-io/egressgateway/issues/953

If the heartbeat logic of the egressgateway is not enabled, we will synchronize the health status of the nodes and switch the eip based on this status. If it is enabled, the switch will be made based on the heartbeat status reported by the agent.

如果未启动 egressgateway 的心跳逻辑，我们将同步 node 节点的健康状况，并根据此状况进行 eip 切换。若已启动，则会根据 agent 报告的心跳状态进行切换。
