### PR TITLE
Add the test case P00002 about default gateway

### DIFF
--- a/test/e2e/common/egp.go
+++ b/test/e2e/common/egp.go
@@ -22,12 +22,16 @@ import (
 )
 
 func CreateEgressPolicyNew(ctx context.Context, cli client.Client, cfg econfig.FileConfig,
-	egw string, podLabel map[string]string) (*egressv1.EgressPolicy, error) {
+	egw string, podLabel map[string]string, namespace string) (*egressv1.EgressPolicy, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*20)
 	defer cancel()
 
+	if len(namespace) == 0 {
+		namespace = "default"
+	}
+
 	res := &egressv1.EgressPolicy{
-		ObjectMeta: metav1.ObjectMeta{GenerateName: "policy-" + uuid.NewString(), Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "policy-" + uuid.NewString(), Namespace: namespace},
 		Spec: egressv1.EgressPolicySpec{
 			EgressGatewayName: egw,
 			AppliedTo: egressv1.AppliedTo{PodSelector: &metav1.LabelSelector{

--- a/test/e2e/egressendpointslice/egressendpointslice_test.go
+++ b/test/e2e/egressendpointslice/egressendpointslice_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Egressendpointslice", func() {
 			GinkgoWriter.Printf("succeeded to create deploy %s\n", deploy.Name)
 
 			// create policy
-			egp, err = common.CreateEgressPolicyNew(ctx, cli, egressConfig, egw.Name, deploy.Labels)
+			egp, err = common.CreateEgressPolicyNew(ctx, cli, egressConfig, egw.Name, deploy.Labels, "")
 			Expect(err).NotTo(HaveOccurred(), "failed to create policy")
 			GinkgoWriter.Printf("succeeded to create policy %s\n", egp.Name)
 

--- a/test/e2e/egressgateway/egressgateway_test.go
+++ b/test/e2e/egressgateway/egressgateway_test.go
@@ -467,7 +467,7 @@ var _ = Describe("Operate EgressGateway", Label("EgressGateway"), Ordered, func(
 			v6DefaultEip = egw.Spec.Ippools.Ipv6DefaultEIP
 
 			// create egressPolicy
-			egp, err = common.CreateEgressPolicyNew(ctx, cli, egressConfig, egw.Name, ds.Labels)
+			egp, err = common.CreateEgressPolicyNew(ctx, cli, egressConfig, egw.Name, ds.Labels, "")
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Printf("Succeeded create EgressPolicy: %s\n", egp.Name)
 
@@ -673,7 +673,7 @@ var _ = Describe("Operate EgressGateway", Label("EgressGateway"), Ordered, func(
 			Expect(egw.GetFinalizers()).Should(ContainElement(gatewayFinalizer), "failed to check egressgateway finzalizer")
 
 			// create egressPolicy
-			egp, err = common.CreateEgressPolicyNew(ctx, cli, egressConfig, egw.Name, label)
+			egp, err = common.CreateEgressPolicyNew(ctx, cli, egressConfig, egw.Name, label, "")
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Printf("Succeeded create EgressPolicy: %s\n", egp.Name)
 

--- a/test/e2e/reliability/reliability_test.go
+++ b/test/e2e/reliability/reliability_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Reliability", func() {
 			GinkgoWriter.Printf("Create DaemonSet: %s\n", daemonSet.Name)
 
 			// policy
-			policy, err = common.CreateEgressPolicyNew(ctx, cli, egressConfig, egw.Name, daemonSet.Labels)
+			policy, err = common.CreateEgressPolicyNew(ctx, cli, egressConfig, egw.Name, daemonSet.Labels, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			// check eip


### PR DESCRIPTION
- test about default gateway
1. When creating a cluster-level policy without specifying a gatewayName, it will use the cluster's default gateway if it exists.
2. When creating a namespace-level policy without specifying a gatewayName, it will use the namespace's default gateway or the cluster's default gateway. If both default gateways exist, the policy will use the namespace-level default gateway.

- open some test case