### PR TITLE
[ update install calico ] specify the calico version manually when failed to retrieve it

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -182,6 +182,7 @@ E2E_KIND_IPV6_POD_CIDR = fd40::/48
 
 #====== calico
 CALICO_VERSION ?=
+MAMUAL_CALICO_VERSION ?= v3.26.4
 INSTALL_TIME_OUT = 300s
 ifeq ($(E2E_CHINA_IMAGE_REGISTRY),true)
     CALICO_REGISTRY ?= docker.m.daocloud.io

--- a/test/scripts/installCalico.sh
+++ b/test/scripts/installCalico.sh
@@ -22,10 +22,11 @@ CALICO_CONFIG=${DEST_CALICO_YAML_DIR}/calico_config.yaml
 CALICO_NODE=${DEST_CALICO_YAML_DIR}/calico_node.yaml
 
 # CALICO_VERSION
+# CALICO_VERSION
 if [ -z "${CALICO_VERSION}" ]; then
-  [ -n "${HTTP_PROXY}" ] && calico_tag=$(curl --retry 3 --retry-delay 5 -x "${HTTP_PROXY}" -s https://api.github.com/repos/projectcalico/calico/releases/latest | jq -r '.tag_name')
-  [ -z "${HTTP_PROXY}" ] && calico_tag=$(curl --retry 3 --retry-delay 5 -s https://api.github.com/repos/projectcalico/calico/releases/latest | jq -r '.tag_name')
-  [ "${calico_tag}" == "null" ] && { echo "failed get calico version"; exit 1; }
+  [ -n "${HTTP_PROXY}" ] && { calico_info_json=$(curl --retry 3 --retry-delay 5 -x "${HTTP_PROXY}" -s https://api.github.com/repos/projectcalico/calico/releases/latest); echo ${calico_info_json}; calico_tag=$(echo ${calico_info_json} | jq -r '.tag_name'); }
+  [ -z "${HTTP_PROXY}" ] && { calico_info_json=$(curl --retry 3 --retry-delay 5 -s https://api.github.com/repos/projectcalico/calico/releases/latest); echo ${calico_info_json}; calico_tag=$(echo ${calico_info_json} | jq -r '.tag_name'); }
+  [ "${calico_tag}" == "null" ] && { echo "failed to get the calico version, specify the version manually"; calico_tag=${MANUAL_CALICO_VERSION}; }
 else
   calico_tag=${CALICO_VERSION}
 fi


### PR DESCRIPTION
Specify the calico version manually when failed to retrieve it when install calico
Fix #1034