### PR TITLE
Revert "Merge pull request #1062 from spidernet-io/dependabot/github_actions/actions/upload-artifact-4.0.0"

### DIFF
--- a/.github/workflows/build-image-base.yaml
+++ b/.github/workflows/build-image-base.yaml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Upload artifact digests
         if: ${{ env.RUN_EXIST == 'false' }}
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: image-digest-${{ matrix.name }}
           path: image-digest

--- a/.github/workflows/call-e2e.yaml
+++ b/.github/workflows/call-e2e.yaml
@@ -160,7 +160,7 @@ jobs:
           fi
 
       - name: Upload e2e cluster log
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: ${{ inputs.ipfamily }}-debuglog-${{ env.RUN_VAR }}.txt
           path: ${{ env.E2E_LOG_PATH }}
@@ -168,7 +168,7 @@ jobs:
 
       - name: Upload e2e ginkgo report
         if: ${{ env.RUN_UPLOAD_LOG == 'true' }}
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: ${{ inputs.ipfamily }}-e2e-report-${{ env.RUN_VAR }}.json
           path: ${{ env.E2E_GINKGO_REPORT_PATH }}

--- a/.github/workflows/call-release-changelog.yaml
+++ b/.github/workflows/call-release-changelog.yaml
@@ -109,7 +109,7 @@ jobs:
           cat ${FILE_PATH}
 
       - name: Upload Changelog
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: changelog_artifact
           path: ${{ env.FILE_PATH }}

--- a/.github/workflows/call-release-chart.yaml
+++ b/.github/workflows/call-release-chart.yaml
@@ -70,7 +70,7 @@ jobs:
           make chart_package
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: chart_package_artifact
           path: ${{ env.CHART_OUTPUT_PATH }}

--- a/.github/workflows/call-release-image.yaml
+++ b/.github/workflows/call-release-image.yaml
@@ -223,14 +223,14 @@ jobs:
           cd ..
 
       - name: Upload artifact digests
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: image-digest-artifact-${{ env.RUN_IMAGE_TAG }}
           path: image-digest-output.txt
           retention-days: 1
 
       - name: Upload artifact digests
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: makefile-digest-artifact-${{ env.RUN_IMAGE_TAG }}
           path: Makefile.digests
@@ -239,7 +239,7 @@ jobs:
       # Upload artifact race images tar
       - name: Upload image artifact
         if: ${{ env.RUN_UPLOAD == 'true' }}
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: image-tar-${{ env.RUN_IMAGE_SUFFIX }}
           path: /tmp/${{ env.RUN_IMAGE_SUFFIX }}.tar

--- a/.github/workflows/call-release-pages.yaml
+++ b/.github/workflows/call-release-pages.yaml
@@ -133,7 +133,7 @@ jobs:
           echo "Push a doc version: ${{ env.DOCS_TAG }} from branch: ${{ env.REF }}, update it to latest: ${{ env.SET_LATEST }} "
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: site_artifact
           path: site.tar.gz

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -53,7 +53,7 @@ jobs:
           echo "-----------------------------"
 
       - name: Upload artifact digests
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: README.md
           path: thisProject/charts/README.md

--- a/.github/workflows/lint-golang.yaml
+++ b/.github/workflows/lint-golang.yaml
@@ -179,7 +179,7 @@ jobs:
 
       - name: Upload Coverage Artifact
         if: ${{ steps.unitest.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: coverage.out
           path: ${{ env.COVERAGE_REPORT_PATH }}
@@ -187,7 +187,7 @@ jobs:
 
       - name: Upload Report Artifact
         if: ${{ steps.unitest.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: unitestreport.json
           path: ${{ env.UNITEST_REPORT_PATH }}

--- a/.github/workflows/lint-yaml.yaml
+++ b/.github/workflows/lint-yaml.yaml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload artifact digests
         if: ${{ steps.yaml-lint.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: log
           path: ${{ steps.yaml-lint.outputs.logfile }}


### PR DESCRIPTION
Revert actions/upload-artifact from 4.0.0 to 3.1.3 
As https://github.com/actions/upload-artifact say: 
upload-artifact@v4+ is not currently supported on GHES yet. If you are on GHES, you must use [v3](https://github.com/actions/upload-artifact/releases/tag/v3).