### PR TITLE
Revert actions/download-artifact from 4.0.0 to 3.0.2

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -121,13 +121,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Chart Artifact
-        uses: actions/download-artifact@v4.0.0
+        uses: actions/download-artifact@v3.0.2
         with:
           name: ${{ needs.release-chart.outputs.artifact }}
           path: chart-package/
 
       - name: Download Changelog Artifact
-        uses: actions/download-artifact@v4.0.0
+        uses: actions/download-artifact@v3.0.2
         with:
           name: ${{ needs.release-changelog.outputs.artifact }}
           path: changelog-result/

--- a/.github/workflows/build-image-base.yaml
+++ b/.github/workflows/build-image-base.yaml
@@ -168,7 +168,7 @@ jobs:
           mkdir -p image-digest/
 
       - name: Download digests of all images built
-        uses: actions/download-artifact@v4.0.0
+        uses: actions/download-artifact@v3.0.2
         with:
           path: image-digest/
 

--- a/.github/workflows/call-e2e.yaml
+++ b/.github/workflows/call-e2e.yaml
@@ -90,7 +90,7 @@ jobs:
       # download all artifact
       # https://github.com/actions/download-artifact#download-all-artifacts
       - name: Download images
-        uses: actions/download-artifact@v4.0.0
+        uses: actions/download-artifact@v3.0.2
         with:
           path: output/artifact-${{ inputs.ipfamily }}
 

--- a/.github/workflows/call-release-changelog.yaml
+++ b/.github/workflows/call-release-changelog.yaml
@@ -126,7 +126,7 @@ jobs:
           ref: ${{ env.DEST_BRANCH }}
 
       - name: Download Artifact
-        uses: actions/download-artifact@v4.0.0
+        uses: actions/download-artifact@v3.0.2
         with:
           name: changelog_artifact
           path: ${{ env.DEST_DIRECTORY }}

--- a/.github/workflows/call-release-chart.yaml
+++ b/.github/workflows/call-release-chart.yaml
@@ -93,7 +93,7 @@ jobs:
         uses: azure/setup-helm@v3.5
 
       - name: Download Chart Artifact
-        uses: actions/download-artifact@v4.0.0
+        uses: actions/download-artifact@v3.0.2
         with:
           name: chart_package_artifact
           path: charts

--- a/.github/workflows/call-release-pages.yaml
+++ b/.github/workflows/call-release-pages.yaml
@@ -153,7 +153,7 @@ jobs:
 
       ## doc
       - name: Download Artifact
-        uses: actions/download-artifact@v4.0.0
+        uses: actions/download-artifact@v3.0.2
         with:
           name: site_artifact
 

--- a/.github/workflows/call-trivy.yaml
+++ b/.github/workflows/call-trivy.yaml
@@ -21,7 +21,7 @@ jobs:
 
       # download all artifact
       - name: Download images
-        uses: actions/download-artifact@v4.0.0
+        uses: actions/download-artifact@v3.0.2
         with:
           path: output/artifact-trivy
 


### PR DESCRIPTION

As https://github.com/actions/download-artifact say:
download-artifact@v4+ is not currently supported on GHES yet. If you are on GHES, you must use [v3](https://github.com/actions/download-artifact/releases/tag/v3).