### PR TITLE
E2E: enhance the test cases stability

### DIFF
--- a/test/e2e/common/ds.go
+++ b/test/e2e/common/ds.go
@@ -15,8 +15,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func CreateDaemonSet(ctx context.Context, cli client.Client, name string, image string) (*appsv1.DaemonSet, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Second*20)
+func CreateDaemonSet(ctx context.Context, cli client.Client, name string, image string, timeout time.Duration) (*appsv1.DaemonSet, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	var terminationGracePeriodSeconds int64 = 0

--- a/test/e2e/egressendpointslice/egressendpointslice_test.go
+++ b/test/e2e/egressendpointslice/egressendpointslice_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Egressendpointslice", func() {
 			ees, err := common.GetEgressEndPointSliceByEgressPolicy(ctx, cli, egp)
 			Expect(err).NotTo(HaveOccurred())
 			if ees != nil {
-				Expect(common.WaitEgressEndPointSliceDeleted(ctx, cli, ees, time.Second*5)).NotTo(HaveOccurred())
+				Expect(common.WaitEgressEndPointSliceDeleted(ctx, cli, ees, time.Minute)).NotTo(HaveOccurred())
 			}
 		})
 
@@ -167,7 +167,7 @@ var _ = Describe("Egressendpointslice", func() {
 			eces, err := common.GetEgressClusterEndPointSliceByEgressClusterPolicy(ctx, cli, egcp)
 			Expect(err).NotTo(HaveOccurred())
 			if eces != nil {
-				Expect(common.WaitEgressClusterEndPointSliceDeleted(ctx, cli, eces, time.Second*5)).NotTo(HaveOccurred())
+				Expect(common.WaitEgressClusterEndPointSliceDeleted(ctx, cli, eces, time.Minute)).NotTo(HaveOccurred())
 			}
 		})
 	})

--- a/test/e2e/egressgateway/egressgateway_test.go
+++ b/test/e2e/egressgateway/egressgateway_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Operate EgressGateway", Label("EgressGateway"), Ordered, func(
 			ctx = context.Background()
 
 			// create DaemonSet
-			ds, err = common.CreateDaemonSet(ctx, cli, "ds-"+faker.Word(), config.Image)
+			ds, err = common.CreateDaemonSet(ctx, cli, "ds-"+faker.Word(), config.Image, time.Minute/2)
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Printf("succeeded to create DaemonSet: %s\n", ds.Name)
 			podLabelSelector = &metav1.LabelSelector{MatchLabels: ds.Labels}
@@ -457,7 +457,7 @@ var _ = Describe("Operate EgressGateway", Label("EgressGateway"), Ordered, func(
 			var err error
 
 			// create ds for eip test
-			ds, err = common.CreateDaemonSet(ctx, cli, "ds-"+faker.Word(), config.Image)
+			ds, err = common.CreateDaemonSet(ctx, cli, "ds-"+faker.Word(), config.Image, time.Minute/2)
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Printf("Create DaemonSet: %s\n", ds.Name)
 

--- a/test/e2e/egresspolicy/egresspolicy_test.go
+++ b/test/e2e/egresspolicy/egresspolicy_test.go
@@ -82,11 +82,11 @@ var _ = Describe("EgressPolicy", Serial, func() {
 			ctx := context.Background()
 			var err error
 			// create DaemonSet-A DaemonSet-B for A/B test
-			dsA, err = common.CreateDaemonSet(ctx, cli, "ds-a-"+faker.Word(), config.Image)
+			dsA, err = common.CreateDaemonSet(ctx, cli, "ds-a-"+faker.Word(), config.Image, time.Minute/2)
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Printf("Create DaemonSet A: %s\n", dsA.Name)
 
-			dsB, err = common.CreateDaemonSet(ctx, cli, "ds-b-"+faker.Word(), config.Image)
+			dsB, err = common.CreateDaemonSet(ctx, cli, "ds-b-"+faker.Word(), config.Image, time.Minute/2)
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Printf("Create DaemonSet B: %s\n", dsB.Name)
 
@@ -521,7 +521,7 @@ var _ = Describe("EgressPolicy", Serial, func() {
 				ctx = context.Background()
 
 				// create DaemonSet
-				ds, err = common.CreateDaemonSet(ctx, cli, "ds-"+uuid.NewString(), config.Image)
+				ds, err = common.CreateDaemonSet(ctx, cli, "ds-"+uuid.NewString(), config.Image, time.Minute/2)
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoWriter.Printf("succeeded to create DaemonSet: %s\n", ds.Name)
 				podLabelSelector = &metav1.LabelSelector{MatchLabels: ds.Labels}

--- a/test/e2e/reliability/reliability_ip_test.go
+++ b/test/e2e/reliability/reliability_ip_test.go
@@ -29,8 +29,8 @@ var _ = Describe("IP Allocation", Label("Reliability_IP"), func() {
 	var ctx context.Context
 
 	const (
-		creationThresholdTime = time.Second * 10
-		deletionThresholdTime = time.Second * 10
+		creationThresholdTime = time.Second * 30
+		deletionThresholdTime = time.Second * 30
 	)
 
 	BeforeEach(func() {
@@ -71,7 +71,7 @@ var _ = Describe("IP Allocation", Label("Reliability_IP"), func() {
 	It("test IP allocation", Label("R00008", "P00009"), Serial, func() {
 		// create egresspolicies
 		By("create egressPolicies by gaven pods")
-		egps, _, err = common.CreateEgressPoliciesForPods(ctx, cli, egw, pods, egressConfig.EnableIPv4, egressConfig.EnableIPv6, time.Second*10)
+		egps, _, err = common.CreateEgressPoliciesForPods(ctx, cli, egw, pods, egressConfig.EnableIPv4, egressConfig.EnableIPv6, creationThresholdTime)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("create extra egressPolicies")


### PR DESCRIPTION
Fix #1108, increase the time to wait policy status to be synced
Fix #1109, add retry in function DeletePodsUntilReady in the file test/e2e/common/pod.go
Fix #1110, ensure the container runing when check the egressIP of the pod
Fix #1111, increase the time to wait egressendpointslice to be deleted
Fix #1126, increase the time to wait daemonset created