### PR TITLE
fix 'Failed to combine cover profiles'

### DIFF
--- a/pkg/agent/route/route_test.go
+++ b/pkg/agent/route/route_test.go
@@ -60,11 +60,6 @@ func TestPurgeStaleRules(t *testing.T) {
 			if tc.prepare != nil {
 				patchess := tc.prepare()
 				patches = append(patches, patchess...)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 			if tc.expErr {
 				err = ruleRoute.PurgeStaleRules(marks, baseMark)
@@ -72,6 +67,9 @@ func TestPurgeStaleRules(t *testing.T) {
 			} else {
 				err = ruleRoute.PurgeStaleRules(marks, baseMark)
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -124,11 +122,6 @@ func TestEnsure(t *testing.T) {
 			if tc.makePatch != nil {
 				patchess := tc.makePatch(ruleRoute)
 				patches = append(patches, patchess...)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			name, ipv4, ipv6, table, mark := tc.prepare()
@@ -138,6 +131,10 @@ func TestEnsure(t *testing.T) {
 			} else {
 				err = ruleRoute.Ensure(name, ipv4, ipv6, table, mark)
 				assert.NoError(t, err)
+			}
+
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -183,11 +180,6 @@ func TestEnsureRoute(t *testing.T) {
 			if tc.makePatch != nil {
 				patchess := tc.makePatch()
 				patches = append(patches, patchess...)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			name, ip, family, table, log := tc.prepare()
@@ -197,6 +189,10 @@ func TestEnsureRoute(t *testing.T) {
 			} else {
 				err = ruleRoute.EnsureRoute(name, ip, family, table, log)
 				assert.NoError(t, err)
+			}
+
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -246,11 +242,6 @@ func TestEnsureRule(t *testing.T) {
 			if tc.makePatch != nil {
 				patchess := tc.makePatch()
 				patches = append(patches, patchess...)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			family, table, mark, log := tc.prepare()
@@ -260,6 +251,9 @@ func TestEnsureRule(t *testing.T) {
 			} else {
 				err = ruleRoute.EnsureRule(family, table, mark, log)
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}

--- a/pkg/agent/vxlan/vxlan_test.go
+++ b/pkg/agent/vxlan/vxlan_test.go
@@ -217,11 +217,6 @@ func Test_EnsureLink(t *testing.T) {
 			if tc.patchFunc != nil {
 				patchess := tc.patchFunc(dev)
 				patches = append(patches, patchess...)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			name, vni, port, mac, mtu, ipv4, ipv6, disableChecksumOffload := tc.prepare()
@@ -230,6 +225,9 @@ func Test_EnsureLink(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -285,11 +283,6 @@ func Test_ensureLink(t *testing.T) {
 			if tc.patchFunc != nil {
 				patchess := tc.patchFunc()
 				patches = append(patches, patchess...)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			_, err = dev.ensureLink(vxlan)
@@ -297,6 +290,10 @@ func Test_ensureLink(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -339,11 +336,6 @@ func Test_ListNeigh(t *testing.T) {
 			if tc.patchFunc != nil {
 				patchess := tc.patchFunc(dev)
 				patches = append(patches, patchess...)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			_, err = dev.ListNeigh()
@@ -351,6 +343,9 @@ func Test_ListNeigh(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -402,11 +397,6 @@ func Test_Add(t *testing.T) {
 			if tc.patchFunc != nil {
 				patchess := tc.patchFunc(dev)
 				patches = append(patches, patchess...)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			err = dev.Add(peer)
@@ -414,6 +404,9 @@ func Test_Add(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -450,11 +443,6 @@ func Test_add(t *testing.T) {
 			if tc.patchFunc != nil {
 				patchess := tc.patchFunc(dev)
 				patches = append(patches, patchess...)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			err = dev.add(mac, ip)
@@ -462,6 +450,10 @@ func Test_add(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -500,11 +492,6 @@ func Test_Del(t *testing.T) {
 			if tc.patchFunc != nil {
 				patchess := tc.patchFunc(dev)
 				patches = append(patches, patchess...)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			err = dev.Del(neigh)
@@ -512,6 +499,9 @@ func Test_Del(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -567,11 +557,6 @@ func Test_ensureAddr(t *testing.T) {
 			if tc.patchFunc != nil {
 				patchess := tc.patchFunc()
 				patches = append(patches, patchess...)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			err = dev.ensureAddr(ipn, link, family)
@@ -579,6 +564,9 @@ func Test_ensureAddr(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -626,11 +614,6 @@ func Test_writeProcSys(t *testing.T) {
 			if tc.patchFunc != nil {
 				patchess := tc.patchFunc()
 				patches = append(patches, patchess...)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			err = writeProcSys(path, value)
@@ -638,6 +621,9 @@ func Test_writeProcSys(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -179,17 +179,15 @@ func Test_LoadConfig(t *testing.T) {
 
 			patchess := tc.patchFunc()
 			patches = append(patches, patchess...)
-			defer func() {
-				for _, p := range patches {
-					p.Reset()
-				}
-			}()
 
 			_, err := LoadConfig(tc.setParams())
 			if tc.expErr {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 

--- a/pkg/controller/egress_cluster_info/egress_cluster_info_test.go
+++ b/pkg/controller/egress_cluster_info/egress_cluster_info_test.go
@@ -203,13 +203,9 @@ func Test_eciReconciler_reconcileEgressClusterInfo(t *testing.T) {
 				tc.setReconciler(r)
 			}
 
+			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFunc != nil {
-				patches := tc.patchFunc(r)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
+				patches = tc.patchFunc(r)
 			}
 
 			ctx := context.TODO()
@@ -219,6 +215,10 @@ func Test_eciReconciler_reconcileEgressClusterInfo(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -280,13 +280,9 @@ func Test_eciReconciler_reconcileCalicoIPPool(t *testing.T) {
 				tc.setReconciler(r)
 			}
 
+			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFunc != nil {
-				patches := tc.patchFunc(r)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
+				patches = tc.patchFunc(r)
 			}
 
 			ctx := context.TODO()
@@ -296,6 +292,9 @@ func Test_eciReconciler_reconcileCalicoIPPool(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -356,13 +355,9 @@ func Test_eciReconciler_reconcileNode(t *testing.T) {
 				tc.setReconciler(r)
 			}
 
+			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFunc != nil {
-				patches := tc.patchFunc(r)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
+				patches = tc.patchFunc(r)
 			}
 
 			ctx := context.TODO()
@@ -372,6 +367,9 @@ func Test_eciReconciler_reconcileNode(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -454,13 +452,9 @@ func Test_eciReconciler_listCalicoIPPools(t *testing.T) {
 				tc.setReconciler(r)
 			}
 
+			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFunc != nil {
-				patches := tc.patchFunc(r)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
+				patches = tc.patchFunc(r)
 			}
 
 			ctx := context.TODO()
@@ -470,6 +464,10 @@ func Test_eciReconciler_listCalicoIPPools(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -535,13 +533,9 @@ func Test_eciReconciler_getCalicoIPPools(t *testing.T) {
 				tc.setReconciler(r)
 			}
 
+			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFunc != nil {
-				patches := tc.patchFunc(r)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
+				patches = tc.patchFunc(r)
 			}
 
 			ctx := context.TODO()
@@ -551,6 +545,9 @@ func Test_eciReconciler_getCalicoIPPools(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -601,13 +598,9 @@ func Test_eciReconciler_listNodeIPs(t *testing.T) {
 				tc.setReconciler(r)
 			}
 
+			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFunc != nil {
-				patches := tc.patchFunc(r)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
+				patches = tc.patchFunc(r)
 			}
 
 			ctx := context.TODO()
@@ -617,6 +610,10 @@ func Test_eciReconciler_listNodeIPs(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -667,13 +664,9 @@ func Test_eciReconciler_getNodeIPs(t *testing.T) {
 				tc.setReconciler(r)
 			}
 
+			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFunc != nil {
-				patches := tc.patchFunc(r)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
+				patches = tc.patchFunc(r)
 			}
 
 			ctx := context.TODO()
@@ -683,6 +676,9 @@ func Test_eciReconciler_getNodeIPs(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -737,6 +733,8 @@ func Test_eciReconciler_checkCalicoExists(t *testing.T) {
 			})
 
 			time.Sleep(time.Second * 3)
+			patch1.Reset()
+
 			patch2 := gomonkey.ApplyPrivateMethod(r, "listCalicoIPPools", func(_ *eciReconciler) (map[string]egressv1.IPListPair, error) {
 				return nil, nil
 			})
@@ -745,7 +743,6 @@ func Test_eciReconciler_checkCalicoExists(t *testing.T) {
 			patch3 := gomonkey.ApplyFuncReturn(watchSource, nil)
 			patches = append(patches, *patch3)
 
-			patch1.Reset()
 		}()
 
 		time.Sleep(time.Second)
@@ -754,37 +751,72 @@ func Test_eciReconciler_checkCalicoExists(t *testing.T) {
 
 	})
 
-	t.Run("failed listCalicoIPPools", func(t *testing.T) {
+	t.Run("failed watchSource", func(t *testing.T) {
+		calicoIPPoolV4 := &calicov1.IPPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-ippool-v4",
+			},
+			Spec: calicov1.IPPoolSpec{
+				// CIDR: "xxx",
+				CIDR: "10.10.0.0/18",
+			},
+		}
+		calicoIPPoolV6 := &calicov1.IPPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-ippool-v6",
+			},
+			Spec: calicov1.IPPoolSpec{
+				CIDR: "fdee:120::/120",
+			},
+		}
+
+		var objs []client.Object
+
+		builder := fake.NewClientBuilder()
+		builder.WithScheme(schema.GetScheme())
+		objs = append(objs, calicoIPPoolV4, calicoIPPoolV6)
+		builder.WithObjects(objs...)
+		builder.WithStatusSubresource(objs...)
+		cli := builder.Build()
+
+		mgrOpts := manager.Options{
+			Scheme: schema.GetScheme(),
+			NewClient: func(config *rest.Config, options client.Options) (client.Client, error) {
+				return cli, nil
+			},
+		}
+
+		mgr, _ := ctrl.NewManager(&rest.Config{}, mgrOpts)
+
+		r := &eciReconciler{
+			mgr:           mgr,
+			eci:           new(egressv1.EgressClusterInfo),
+			log:           logr.Logger{},
+			k8sPodCidr:    make(map[string]egressv1.IPListPair),
+			v4ClusterCidr: make([]string, 0),
+			v6ClusterCidr: make([]string, 0),
+			client:        cli,
+		}
+		c, _ := controller.New("egressClusterInfo", mgr,
+			controller.Options{Reconciler: r})
+		r.c = c
+
 		r.isWatchCalico.Store(true)
 
 		var patches []gomonkey.Patches
-		defer func() {
-			for _, p := range patches {
-				p.Reset()
-			}
-		}()
 
-		go func() {
-			patch1 := gomonkey.ApplyPrivateMethod(r, "listCalicoIPPools", func(_ *eciReconciler) (map[string]egressv1.IPListPair, error) {
-				return nil, nil
-			})
-			patches = append(patches, *patch1)
-
-			patch2 := gomonkey.ApplyFuncReturn(watchSource, ErrForMock)
-			time.Sleep(time.Second * 3)
-
-			patch3 := gomonkey.ApplyFuncReturn(watchSource, nil)
-			patches = append(patches, *patch3)
-
-			patch2.Reset()
-		}()
-
-		time.Sleep(time.Second)
+		patch2 := gomonkey.ApplyFuncSeq(watchSource, []gomonkey.OutputCell{
+			{Values: gomonkey.Params{ErrForMock}, Times: 3},
+			{Values: gomonkey.Params{nil}, Times: 3},
+		})
+		patches = append(patches, *patch2)
 
 		r.checkCalicoExists()
 
+		for _, p := range patches {
+			p.Reset()
+		}
 	})
-
 }
 
 func Test_eciReconciler_getServiceClusterIPRange(t *testing.T) {
@@ -885,13 +917,9 @@ func Test_eciReconciler_checkSomeCniExists(t *testing.T) {
 				tc.setReconciler(r)
 			}
 
+			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFunc != nil {
-				patches := tc.patchFunc(r)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
+				patches = tc.patchFunc(r)
 			}
 
 			err := r.checkSomeCniExists()
@@ -899,6 +927,9 @@ func Test_eciReconciler_checkSomeCniExists(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}

--- a/pkg/controller/endpoint/cluster_endpoint_slice_test.go
+++ b/pkg/controller/endpoint/cluster_endpoint_slice_test.go
@@ -675,19 +675,18 @@ func Test_NewEgressClusterEpSliceController(t *testing.T) {
 			}
 
 			// patch
+			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFun != nil {
-				patches := tc.patchFun(t, r, mgr, log)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
+				patches = tc.patchFun(t, r, mgr, log)
 			}
 
 			err = NewEgressClusterEpSliceController(mgr, log, cfg)
 
 			if tc.expErr {
 				assert.Error(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -816,19 +815,18 @@ func Test_Reconcile(t *testing.T) {
 			}
 
 			// patch
+			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFun != nil {
-				patches := tc.patchFun(t, r, mgr, log)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
+				patches = tc.patchFun(t, r, mgr, log)
 			}
 
 			_, err = r.Reconcile(context.TODO(), req)
 
 			if tc.expErr {
 				assert.Error(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -891,13 +889,9 @@ func Test_listPodsByClusterPolicy(t *testing.T) {
 			cli := builder.Build()
 
 			// patch
+			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFun != nil {
-				patches := tc.patchFun(cli)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
+				patches = tc.patchFun(cli)
 			}
 
 			policy := tc.setParams()
@@ -905,6 +899,9 @@ func Test_listPodsByClusterPolicy(t *testing.T) {
 
 			if tc.expErr {
 				assert.Error(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -1031,13 +1028,9 @@ func Test_enqueueNS(t *testing.T) {
 			cli := builder.Build()
 
 			// patch
+			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFun != nil {
-				patches := tc.patchFun(cli)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
+				patches = tc.patchFun(cli)
 			}
 
 			resF := enqueueNS(cli)
@@ -1045,6 +1038,9 @@ func Test_enqueueNS(t *testing.T) {
 
 			if tc.expErr {
 				assert.Nil(t, res)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -1266,13 +1262,9 @@ func Test_enqueueEGCP(t *testing.T) {
 			cli := builder.Build()
 
 			// patch
+			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFun != nil {
-				patches := tc.patchFun(cli)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
+				patches = tc.patchFun(cli)
 			}
 
 			resF := enqueueEGCP(cli)
@@ -1280,6 +1272,9 @@ func Test_enqueueEGCP(t *testing.T) {
 
 			if tc.expErr {
 				assert.Nil(t, res)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}

--- a/pkg/controller/endpoint/endpoint_slice_test.go
+++ b/pkg/controller/endpoint/endpoint_slice_test.go
@@ -708,19 +708,18 @@ func Test_NewEgressEndpointSliceController(t *testing.T) {
 			}
 
 			// patch
+			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFun != nil {
-				patches := tc.patchFun(t, r, mgr, log)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
+				patches = tc.patchFun(t, r, mgr, log)
 			}
 
 			err = NewEgressEndpointSliceController(mgr, log, cfg)
 
 			if tc.expErr {
 				assert.Error(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -850,19 +849,18 @@ func Test_endpointReconciler_Reconcile(t *testing.T) {
 			}
 
 			// patch
+			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFun != nil {
-				patches := tc.patchFun(t, r, mgr, log)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
+				patches = tc.patchFun(t, r, mgr, log)
 			}
 
 			_, err = r.Reconcile(context.TODO(), req)
 
 			if tc.expErr {
 				assert.Error(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -1004,13 +1002,9 @@ func Test_listPodsByPolicy(t *testing.T) {
 			cli := builder.Build()
 
 			// patch
+			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFun != nil {
-				patches := tc.patchFun(cli)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
+				patches = tc.patchFun(cli)
 			}
 
 			policy := tc.setParams()
@@ -1018,6 +1012,9 @@ func Test_listPodsByPolicy(t *testing.T) {
 
 			if tc.expErr {
 				assert.Error(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -1159,13 +1156,9 @@ func Test_enqueuePod(t *testing.T) {
 			cli := builder.Build()
 
 			// patch
+			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFun != nil {
-				patches := tc.patchFun(cli)
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
+				patches = tc.patchFun(cli)
 			}
 
 			resF := enqueuePod(cli)
@@ -1173,6 +1166,9 @@ func Test_enqueuePod(t *testing.T) {
 
 			if tc.expErr {
 				assert.Nil(t, res)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}

--- a/pkg/markallocator/allocator_test.go
+++ b/pkg/markallocator/allocator_test.go
@@ -52,12 +52,6 @@ func Test_NewAllocatorMarkRange(t *testing.T) {
 			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFunc != nil {
 				patches = tc.patchFunc()
-
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			_, err := NewAllocatorMarkRange(mark)
@@ -65,6 +59,10 @@ func Test_NewAllocatorMarkRange(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -102,12 +100,6 @@ func Test_RangeSize(t *testing.T) {
 			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFunc != nil {
 				patches = tc.patchFunc()
-
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			_, _, err := RangeSize(mark)
@@ -115,6 +107,9 @@ func Test_RangeSize(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -149,12 +144,6 @@ func Test_Range_Allocate(t *testing.T) {
 			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFunc != nil {
 				patches = tc.patchFunc(&r)
-
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			err := r.Allocate(mark)
@@ -162,6 +151,9 @@ func Test_Range_Allocate(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -191,12 +183,6 @@ func Test_Range_AllocateNext(t *testing.T) {
 			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFunc != nil {
 				patches = tc.patchFunc(&r)
-
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			_, err := r.AllocateNext()
@@ -204,6 +190,9 @@ func Test_Range_AllocateNext(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -230,12 +219,6 @@ func Test_Range_Release(t *testing.T) {
 			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFunc != nil {
 				patches = tc.patchFunc(&r)
-
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			err := r.Release(mark)
@@ -243,6 +226,9 @@ func Test_Range_Release(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -269,17 +255,14 @@ func Test_Range_Has(t *testing.T) {
 			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFunc != nil {
 				patches = tc.patchFunc(&r)
-
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			b := r.Has(mark)
 			if tc.expOK {
 				assert.False(t, b)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}
@@ -302,17 +285,14 @@ func Test_Range_contains(t *testing.T) {
 			patches := make([]gomonkey.Patches, 0)
 			if tc.patchFunc != nil {
 				patches = tc.patchFunc(&r)
-
-				defer func() {
-					for _, p := range patches {
-						p.Reset()
-					}
-				}()
 			}
 
 			b, _ := r.contains(mark)
 			if tc.expOK {
 				assert.False(t, b)
+			}
+			for _, p := range patches {
+				p.Reset()
 			}
 		})
 	}


### PR DESCRIPTION
Fix #1194

```
  Failed to combine cover profiles
  Unable to read coverage file /home/runner/work/egressgateway/egressgateway/pkg/controller/egress_cluster_info/coverage.out.3:
  open /home/runner/work/egressgateway/egressgateway/pkg/controller/egress_cluster_info/coverage.out.3: no such file or directory
```