### PR TITLE
Update cosign to v2.2.3

### DIFF
--- a/.github/workflows/call-release-image.yaml
+++ b/.github/workflows/call-release-image.yaml
@@ -97,7 +97,7 @@ jobs:
         if: ${{ env.RUN_PUSH == 'true' }}
         uses: sigstore/cosign-installer@main
         with:
-          cosign-release: 'v2.0.1' #do not upgrade, or else go error
+          cosign-release: 'v2.2.3' #do not upgrade, or else go error
 
       - name: Getting Build Arg
         id: arg


### PR DESCRIPTION
Fix create release get error:

```
main.go:74: error during command execution: signing [ghcr.io/spidernet-io/egressgateway-nettools@sha256:745978f4eea7422480fc6f5bdf1e97bbd04463a90963c245c0b67b7e570fff7a]: getting signer: getting key from Fulcio: getting CTFE public keys: updating local metadata and targets: error updating to TUF remote mirror: invalid key
```

ref https://github.com/sigstore/cosign/issues/3614