### PR TITLE
Update the health check port to port to prevent conflicts

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -85,7 +85,7 @@ helm install egressgateway egressgateway/egressgateway --namespace kube-system
 | `agent.resources.requests.cpu`                       | The cpu requests of egressgateway agent pod                                                                     | `100m`                             |
 | `agent.resources.requests.memory`                    | The memory requests of egressgateway agent pod                                                                  | `128Mi`                            |
 | `agent.securityContext`                              | The security Context of egressgateway agent pod                                                                 | `{}`                               |
-| `agent.healthServer.port`                            | The http port for health checking of the egressgateway agent.                                                   | `5810`                             |
+| `agent.healthServer.port`                            | The http port for health checking of the egressgateway agent.                                                   | `6610`                             |
 | `agent.healthServer.startupProbe.failureThreshold`   | The failure threshold of startup probe for egressgateway agent health checking                                  | `60`                               |
 | `agent.healthServer.startupProbe.periodSeconds`      | The period seconds of startup probe for egressgateway agent health checking                                     | `2`                                |
 | `agent.healthServer.livenessProbe.failureThreshold`  | The failure threshold of startup probe for egressgateway agent health checking                                  | `6`                                |

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -157,7 +157,7 @@ agent:
 
   healthServer:
     ## @param agent.healthServer.port The http port for health checking of the egressgateway agent.
-    port: 5810
+    port: 6610
     startupProbe:
       ## @param agent.healthServer.startupProbe.failureThreshold The failure threshold of startup probe for egressgateway agent health checking
       failureThreshold: 60


### PR DESCRIPTION
Fix https://github.com/spidernet-io/egressgateway/issues/1187

In the cluster in issues 1187, kube-apiserver used 5810, we change the port we use