### PR TITLE
Bump actions/upload-artifact to v4.3.4

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -121,13 +121,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Chart Artifact
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.1.8
         with:
           name: ${{ needs.release-chart.outputs.artifact }}
           path: chart-package/
 
       - name: Download Changelog Artifact
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.1.8
         with:
           name: ${{ needs.release-changelog.outputs.artifact }}
           path: changelog-result/

--- a/.github/workflows/build-image-base.yaml
+++ b/.github/workflows/build-image-base.yaml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Upload artifact digests
         if: ${{ env.RUN_EXIST == 'false' }}
-        uses: actions/upload-artifact@v4.3.2
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: image-digest-${{ matrix.name }}
           path: image-digest
@@ -168,7 +168,7 @@ jobs:
           mkdir -p image-digest/
 
       - name: Download digests of all images built
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.1.8
         with:
           path: image-digest/
 

--- a/.github/workflows/call-e2e.yaml
+++ b/.github/workflows/call-e2e.yaml
@@ -89,30 +89,27 @@ jobs:
 
       # download all artifact
       # https://github.com/actions/download-artifact#download-all-artifacts
-      - name: Download images
-        uses: actions/download-artifact@v4.1.7
+      - name: Download egressgateway-agent
+        uses: actions/download-artifact@v4.1.8
         with:
+          name: image-tar-egressgateway-agent
+          path: output/artifact-${{ inputs.ipfamily }}
+      - name: Download egressgateway-controller
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: image-tar-egressgateway-controller
+          path: output/artifact-${{ inputs.ipfamily }}
+      - name: Download egressgateway-nettools
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: image-tar-egressgateway-nettools
           path: output/artifact-${{ inputs.ipfamily }}
 
-      - name: Load And Scan Images
+      - name: Load images
         run: |
           PROJECT_DIR=`pwd`
           cd output/artifact-${{ inputs.ipfamily }}
-          ls
-          ALL_DIR=`ls`
-          IMAGE_DIR=""
-          for ITEM in $ALL_DIR ; do
-              grep -E "^image-tar" <<< "${ITEM}" &>/dev/null && IMAGE_DIR+=" ${ITEM} "
-          done
-          echo "IMAGE_DIR=${IMAGE_DIR}"
-          for ITEM in $IMAGE_DIR ; do
-              TAR_FILES=`ls ${ITEM}`
-              ls -l ${ITEM}
-              for TAR in $TAR_FILES ; do
-                echo "image tar ${ITEM}/${TAR}"
-                cat ${ITEM}/${TAR} |  docker import - ${TAR%*.tar}:${{ inputs.ref }}
-              done
-          done
+          find . -name "*.tar" -print0 | xargs -0 -I {} sh -c 'echo "Loading {} ..."; docker load -i "{}"'
           docker images
 
       - name: Run test
@@ -160,7 +157,7 @@ jobs:
           fi
 
       - name: Upload e2e cluster log
-        uses: actions/upload-artifact@v4.3.2
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: ${{ inputs.os }}-${{ inputs.cni }}-${{ inputs.ipfamily }}-${{ env.RUN_VAR }}-debuglog.txt
           path: ${{ env.E2E_LOG_PATH }}
@@ -168,7 +165,7 @@ jobs:
 
       - name: Upload e2e ginkgo report
         if: ${{ env.RUN_UPLOAD_LOG == 'true' }}
-        uses: actions/upload-artifact@v4.3.2
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: ${{ inputs.os }}-${{ inputs.cni }}-${{ inputs.ipfamily }}-${{ env.RUN_VAR }}-e2e-report.json
           path: ${{ env.E2E_GINKGO_REPORT_PATH }}

--- a/.github/workflows/call-release-changelog.yaml
+++ b/.github/workflows/call-release-changelog.yaml
@@ -109,7 +109,7 @@ jobs:
           cat ${FILE_PATH}
 
       - name: Upload Changelog
-        uses: actions/upload-artifact@v4.3.2
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: changelog_artifact
           path: ${{ env.FILE_PATH }}
@@ -126,7 +126,7 @@ jobs:
           ref: ${{ env.DEST_BRANCH }}
 
       - name: Download Artifact
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.1.8
         with:
           name: changelog_artifact
           path: ${{ env.DEST_DIRECTORY }}

--- a/.github/workflows/call-release-chart.yaml
+++ b/.github/workflows/call-release-chart.yaml
@@ -70,7 +70,7 @@ jobs:
           make chart_package
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4.3.2
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: chart_package_artifact
           path: ${{ env.CHART_OUTPUT_PATH }}
@@ -93,7 +93,7 @@ jobs:
         uses: azure/setup-helm@v4
 
       - name: Download Chart Artifact
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.1.8
         with:
           name: chart_package_artifact
           path: charts

--- a/.github/workflows/call-release-image.yaml
+++ b/.github/workflows/call-release-image.yaml
@@ -138,7 +138,7 @@ jobs:
           file: ${{ matrix.dockerfile }}
           provenance: false
           github-token: ${{ secrets.WELAN_PAT }}
-          outputs: type=tar,dest=/tmp/${{ env.RUN_IMAGE_SUFFIX }}.tar
+          outputs: type=docker,dest=/tmp/${{ env.RUN_IMAGE_SUFFIX }}.tar
           platforms: linux/amd64
           tags: |
             ${{ env.ONLINE_REGISTER }}/${{ github.repository }}-${{ matrix.name }}${{ env.RUN_SUFFIX }}:${{ env.RUN_IMAGE_TAG }}
@@ -223,14 +223,14 @@ jobs:
           cd ..
 
       - name: Upload artifact digests
-        uses: actions/upload-artifact@v4.3.2
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: image-digest-${{ matrix.name }}-${{ env.RUN_IMAGE_TAG }}
           path: image-digest-output.txt
           retention-days: 1
 
       - name: Upload artifact digests
-        uses: actions/upload-artifact@v4.3.2
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: makefile-digest-${{ matrix.name }}-${{ env.RUN_IMAGE_TAG }}
           path: Makefile.digests
@@ -239,7 +239,7 @@ jobs:
       # Upload artifact race images tar
       - name: Upload image artifact
         if: ${{ env.RUN_UPLOAD == 'true' }}
-        uses: actions/upload-artifact@v4.3.2
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: image-tar-${{ env.RUN_IMAGE_SUFFIX }}
           path: /tmp/${{ env.RUN_IMAGE_SUFFIX }}.tar

--- a/.github/workflows/call-release-pages.yaml
+++ b/.github/workflows/call-release-pages.yaml
@@ -133,7 +133,7 @@ jobs:
           echo "Push a doc version: ${{ env.DOCS_TAG }} from branch: ${{ env.REF }}, update it to latest: ${{ env.SET_LATEST }} "
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4.3.2
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: site_artifact
           path: site.tar.gz
@@ -153,7 +153,7 @@ jobs:
 
       ## doc
       - name: Download Artifact
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.1.8
         with:
           name: site_artifact
 

--- a/.github/workflows/call-trivy.yaml
+++ b/.github/workflows/call-trivy.yaml
@@ -19,38 +19,44 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.ref }}
 
-      # download all artifact
-      - name: Download images
-        uses: actions/download-artifact@v4.1.7
-        with:
-          path: output/artifact-trivy
 
-      - name: Load And Scan Images
-        run: |
-          PROJECT_DIR=`pwd`
-          cd output/artifact-trivy
-          ls
-          ALL_DIR=`ls`
-          IMAGE_DIR=""
-          for ITEM in $ALL_DIR ; do
-              grep -E "^image-tar" <<< "${ITEM}" &>/dev/null && IMAGE_DIR+=" ${ITEM} "
-          done
-          echo "IMAGE_DIR=${IMAGE_DIR}"
-          RESULT=true
-          for ITEM in $IMAGE_DIR ; do
-              TAR_FILES=`ls ${ITEM}`
-              for TAR in $TAR_FILES ; do
-                echo "image tar ${ITEM}/${TAR}"
-                cat ${ITEM}/${TAR} |  docker import - ${TAR%*.tar}:${{ inputs.ref }}
-                echo "---------trivy checkout image ${TAR%*.tar}:${{ inputs.ref }} --------------------"
-                make -C ${PROJECT_DIR} lint_image_trivy -e IMAGE_NAME=${TAR%*.tar}:${{ inputs.ref }} \
-                    || { RESULT=false ; echo "error, image ${TAR%*.tar}:${{ inputs.ref }} is bad" ; }
-              done
-          done
-          docker images
-          if [ "$RESULT" != "true" ]; then
-              echo "error, image is not secure, see detail on Step 'Load And Scan Images' "
-              exit 1
-          else
-              exit 0
-          fi
+      - name: Download egressgateway-agent
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: image-tar-egressgateway-agent
+          path: output/image
+      - name: Download egressgateway-controller
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: image-tar-egressgateway-controller
+          path: output/image
+      - name: Download egressgateway-nettools
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: image-tar-egressgateway-nettools
+          path: output/image
+
+
+      - name: List downloaded files
+        run: ls -al output/image
+
+
+      # merge to one step
+      # https://github.com/aquasecurity/trivy-action/issues/313
+      - name: Scan agent
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          input: output/image/egressgateway-agent.tar
+          severity: 'CRITICAL,HIGH'
+
+      - name: Scan controller
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          input: output/image/egressgateway-controller.tar
+          severity: 'CRITICAL,HIGH'
+
+      - name: Scan nettools
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          input: output/image/egressgateway-nettools.tar
+          severity: 'CRITICAL,HIGH'

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -53,7 +53,7 @@ jobs:
           echo "-----------------------------"
 
       - name: Upload artifact digests
-        uses: actions/upload-artifact@v4.3.2
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: README.md
           path: thisProject/charts/README.md

--- a/.github/workflows/lint-golang.yaml
+++ b/.github/workflows/lint-golang.yaml
@@ -179,7 +179,7 @@ jobs:
 
       - name: Upload Coverage Artifact
         if: ${{ steps.unitest.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4.3.2
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: coverage.out
           path: ${{ env.COVERAGE_REPORT_PATH }}
@@ -187,7 +187,7 @@ jobs:
 
       - name: Upload Report Artifact
         if: ${{ steps.unitest.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4.3.2
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: unitestreport.json
           path: ${{ env.UNITEST_REPORT_PATH }}

--- a/.github/workflows/lint-yaml.yaml
+++ b/.github/workflows/lint-yaml.yaml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload artifact digests
         if: ${{ steps.yaml-lint.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4.3.2
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: log
           path: ${{ steps.yaml-lint.outputs.logfile }}


### PR DESCRIPTION
Fix CI faild:
https://github.com/spidernet-io/egressgateway/issues/1405
https://github.com/spidernet-io/egressgateway/issues/1403

upload-artifact v4 download all 有兼容性问题，如果 name 字段未填写，意思为下载所有 artifact，观察 👀 到如果 artifact 中包含一个 tar 包的附件，download all 就会出现问题，v3 不会出现问题，但 v3 过几个月就废弃。