### PR TITLE
Fix run on aws ec2 with cilium

### DIFF
--- a/pkg/agent/vxlan/parent.go
+++ b/pkg/agent/vxlan/parent.go
@@ -62,6 +62,10 @@ func GetParentByDefaultRoute(cli NetLink) func(version int) (*Parent, error) {
 			if !addr.IP.IsGlobalUnicast() {
 				continue
 			}
+			ones, bits := addr.Mask.Size()
+			if ones == 32 && bits == 32 || ones == 128 && bits == 128 {
+				continue
+			}
 			return &Parent{Name: link.Attrs().Name, IP: addr.IP, Index: link.Attrs().Index}, nil
 		}
 		return nil, fmt.Errorf("failed to find parent interface")


### PR DESCRIPTION
Fix https://github.com/spidernet-io/egressgateway/issues/1424

##  vxlan
Fix detect vxlan parent IP logic not skip IP addresses with a full subnet mask (e.g., /32 for IPv4 and /128 for IPv6).
On AWS, when main network card has multiple IP, and it is set to default route.

```go
if ones == 32 && bits == 32 || ones == 128 && bits == 128 {
        continue
}
```

## iptables

Add more iptabels accept rule skip cilium rule.

## EgressClusterInfo

Add **kube-controller-manager** labels case, We use these labels to retrieve the kube-controller-manager Pod arguments in order to obtain the cluster CIDR. Since different clusters have different kube-controller-manager labels, the content of the labels also varies.

If not found CalicoIPPool CRD in current cluster, skipping watch CalicoIPPool.