### PR TITLE
Fix `TOOMANYREQUESTS` failure in Trivy Action

### DIFF
--- a/.github/workflows/call-trivy.yaml
+++ b/.github/workflows/call-trivy.yaml
@@ -45,18 +45,24 @@ jobs:
       # https://github.com/aquasecurity/trivy-action/issues/313
       - name: Scan agent
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db
         with:
           input: output/image/egressgateway-agent.tar
           severity: 'CRITICAL,HIGH'
 
       - name: Scan controller
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db
         with:
           input: output/image/egressgateway-controller.tar
           severity: 'CRITICAL,HIGH'
 
       - name: Scan nettools
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db
         with:
           input: output/image/egressgateway-nettools.tar
           severity: 'CRITICAL,HIGH'


### PR DESCRIPTION
ref:
https://github.com/aquasecurity/trivy-action/issues/389

fix:
https://github.com/spidernet-io/egressgateway/issues/1546

reason:
The rate limiting is for the downloads from the GitHub container registry. As a solution, this PR adds the public ECR registry as a fallback option when the rate limit hits with the GitHub container registry.

