### PR TITLE
Reduce egress gateway agent event

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -28,7 +28,7 @@ type Agent struct {
 }
 
 func New(cfg *config.Config) (types.Service, error) {
-	syncPeriod := time.Second * 15
+	syncPeriod := time.Second * time.Duration(cfg.FileConfig.CacheSyncSyncPeriodSecond)
 	log := logger.NewLogger(cfg.EnvConfig.Logger)
 	t := time.Duration(0)
 	mgrOpts := manager.Options{

--- a/pkg/agent/vxlan.go
+++ b/pkg/agent/vxlan.go
@@ -81,12 +81,6 @@ func (r *vxlanReconciler) Reconcile(ctx context.Context, req reconcile.Request) 
 		return r.reconcileEgressTunnel(ctx, newReq, log)
 	case "EgressGateway":
 		return r.reconcileEgressGateway(ctx, newReq, log)
-	case "EgressEndpointSlice":
-		// return r.reconcileEgressEndpointSlice(ctx, newReq, log)
-		return reconcile.Result{}, nil
-	case "EgressClusterEndpointSlice":
-		// return r.reconcileEgressClusterEndpointSlice(ctx, newReq, log)
-		return reconcile.Result{}, nil
 	default:
 		return reconcile.Result{}, nil
 	}
@@ -642,25 +636,10 @@ func newEgressTunnelController(mgr manager.Manager, cfg *config.Config, log logr
 
 	sourceEgressGateway := utils.SourceKind(mgr.GetCache(),
 		&egressv1.EgressGateway{},
-		handler.EnqueueRequestsFromMapFunc(utils.KindToMapFlat("EgressGateway")))
+		handler.EnqueueRequestsFromMapFunc(utils.KindToMapFlat("EgressGateway")),
+	)
 	if err := c.Watch(sourceEgressGateway); err != nil {
 		return fmt.Errorf("failed to watch EgressGateway: %w", err)
-	}
-
-	sourceEgressEndpointSlice := utils.SourceKind(mgr.GetCache(),
-		&egressv1.EgressEndpointSlice{},
-		handler.EnqueueRequestsFromMapFunc(utils.KindToMapFlat("EgressEndpointSlice")),
-		epSlicePredicate{})
-	if err := c.Watch(sourceEgressEndpointSlice); err != nil {
-		return fmt.Errorf("failed to watch EgressEndpointSlice: %w", err)
-	}
-
-	sourceEgressClusterEndpointSlice := utils.SourceKind(mgr.GetCache(),
-		&egressv1.EgressClusterEndpointSlice{},
-		handler.EnqueueRequestsFromMapFunc(utils.KindToMapFlat("EgressClusterEndpointSlice")),
-		epSlicePredicate{})
-	if err := c.Watch(sourceEgressClusterEndpointSlice); err != nil {
-		return fmt.Errorf("failed to watch EgressClusterEndpointSlice: %w", err)
 	}
 
 	go r.keepVXLAN()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,26 +66,26 @@ type EnvConfig struct {
 }
 
 type FileConfig struct {
-	EnableIPv4                   bool            `yaml:"enableIPv4"`
-	EnableIPv6                   bool            `yaml:"enableIPv6"`
-	IPTables                     IPTables        `yaml:"iptables"`
-	DatapathMode                 string          `yaml:"datapathMode"`
-	TunnelIpv4Subnet             string          `yaml:"tunnelIpv4Subnet"`
-	TunnelIpv6Subnet             string          `yaml:"tunnelIpv6Subnet"`
-	TunnelIPv4Net                *net.IPNet      `json:"-"`
-	TunnelIPv6Net                *net.IPNet      `json:"-"`
-	TunnelDetectMethod           string          `yaml:"tunnelDetectMethod"`
-	VXLAN                        VXLAN           `yaml:"vxlan"`
-	MaxNumberEndpointPerSlice    int             `yaml:"maxNumberEndpointPerSlice"`
-	Mark                         string          `yaml:"mark"`
-	AnnouncedInterfacesToExclude []string        `yaml:"announcedInterfacesToExclude"`
-	AnnounceExcludeRegexp        *regexp.Regexp  `json:"-"`
-	EnableGatewayReplyRoute      bool            `yaml:"enableGatewayReplyRoute"`
-	GatewayReplyRouteTable       int             `yaml:"gatewayReplyRouteTable"`
-	GatewayReplyRouteMark        int             `yaml:"gatewayReplyRouteMark"`
-	GatewayFailover              GatewayFailover `yaml:"gatewayFailover"`
-
-	TunnelDetectCustomInterface []TunnelDetectCustomInterface `yaml:"tunnelDetectCustomInterface"`
+	EnableIPv4                   bool                          `yaml:"enableIPv4"`
+	EnableIPv6                   bool                          `yaml:"enableIPv6"`
+	IPTables                     IPTables                      `yaml:"iptables"`
+	DatapathMode                 string                        `yaml:"datapathMode"`
+	TunnelIpv4Subnet             string                        `yaml:"tunnelIpv4Subnet"`
+	TunnelIpv6Subnet             string                        `yaml:"tunnelIpv6Subnet"`
+	TunnelIPv4Net                *net.IPNet                    `json:"-"`
+	TunnelIPv6Net                *net.IPNet                    `json:"-"`
+	TunnelDetectMethod           string                        `yaml:"tunnelDetectMethod"`
+	VXLAN                        VXLAN                         `yaml:"vxlan"`
+	MaxNumberEndpointPerSlice    int                           `yaml:"maxNumberEndpointPerSlice"`
+	Mark                         string                        `yaml:"mark"`
+	AnnouncedInterfacesToExclude []string                      `yaml:"announcedInterfacesToExclude"`
+	AnnounceExcludeRegexp        *regexp.Regexp                `json:"-"`
+	EnableGatewayReplyRoute      bool                          `yaml:"enableGatewayReplyRoute"`
+	GatewayReplyRouteTable       int                           `yaml:"gatewayReplyRouteTable"`
+	GatewayReplyRouteMark        int                           `yaml:"gatewayReplyRouteMark"`
+	GatewayFailover              GatewayFailover               `yaml:"gatewayFailover"`
+	TunnelDetectCustomInterface  []TunnelDetectCustomInterface `yaml:"tunnelDetectCustomInterface"`
+	CacheSyncSyncPeriodSecond    int                           `json:"cacheSyncSyncPeriodSecond "`
 }
 
 type GatewayFailover struct {
@@ -170,6 +170,7 @@ func LoadConfig(isAgent bool) (*Config, error) {
 				TunnelUpdatePeriod:  5,
 				EipEvictionTimeout:  15,
 			},
+			CacheSyncSyncPeriodSecond: 1800,
 		},
 	}
 

--- a/pkg/controller/endpoint/endpoint_slice.go
+++ b/pkg/controller/endpoint/endpoint_slice.go
@@ -6,7 +6,6 @@ package endpoint
 import (
 	"context"
 	"fmt"
-	"github.com/spidernet-io/egressgateway/pkg/utils"
 	"net"
 	"reflect"
 	"sort"
@@ -32,6 +31,7 @@ import (
 	"github.com/spidernet-io/egressgateway/pkg/coalescing"
 	"github.com/spidernet-io/egressgateway/pkg/config"
 	"github.com/spidernet-io/egressgateway/pkg/k8s/apis/v1beta1"
+	"github.com/spidernet-io/egressgateway/pkg/utils"
 )
 
 type endpointReconciler struct {


### PR DESCRIPTION
This PR removes an unnecessary watch event, significantly reducing log output.

Fix https://github.com/spidernet-io/egressgateway/issues/1491