### PR TITLE
fix: correctly generate an array for egress cluster info with extra cidrs

### DIFF
--- a/charts/templates/egressClusterInfo.yaml
+++ b/charts/templates/egressClusterInfo.yaml
@@ -7,4 +7,7 @@ spec:
     clusterIP: {{ .Values.feature.clusterCIDR.autoDetect.clusterIP }}
     podCidrMode: {{ .Values.feature.clusterCIDR.autoDetect.podCidrMode }}
     nodeIP: {{ .Values.feature.clusterCIDR.autoDetect.nodeIP }}
-  extraCidr: {{ .Values.feature.clusterCIDR.extraCidr }}
+{{- if .Values.feature.clusterCIDR.extraCidr }}
+  extraCidr:
+{{ .Values.feature.clusterCIDR.extraCidr | toYaml | indent 4 }}
+{{ end -}}


### PR DESCRIPTION
Otherwise it's not possible to deploy multiple cidrs via Flux.