### PR TITLE
Fix base image build failure in GitHub Workflow

### DIFF
--- a/.github/workflows/build-image-base.yaml
+++ b/.github/workflows/build-image-base.yaml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Upload artifact digests
         if: ${{ env.RUN_EXIST == 'false' }}
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: image-digest-${{ matrix.name }}
           path: image-digest
@@ -168,12 +168,16 @@ jobs:
           mkdir -p image-digest/
 
       - name: Download digests of all images built
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v4.3.0
         with:
           path: image-digest/
+          pattern: "image-digest-*"
+          merge-multiple: true
 
       - name: Image Digests Output
         shell: bash
         run: |
           cd image-digest/
+          ls -l
+          echo "---------------------------------"
           find -type f | sort | xargs -d '\n' cat

--- a/images/controller-base/build-gops.sh
+++ b/images/controller-base/build-gops.sh
@@ -9,7 +9,7 @@ set -o pipefail
 set -o nounset
 
 # https://github.com/google/gops
-gops_version="v0.3.25"
+gops_version="v0.3.27"
 
 mkdir -p /go/src/github.com/google
 cd /go/src/github.com/google


### PR DESCRIPTION
Fix base image build failure in GitHub Workflow. I have tested the update on this branch. GitHub Actions URL: https://github.com/spidernet-io/egressgateway/actions/runs/15435084161