### PR TITLE
Escape marked tunnel trafic from egress-gateway processing in mangle table (#1616)

### DIFF
--- a/pkg/agent/police.go
+++ b/pkg/agent/police.go
@@ -847,8 +847,12 @@ func buildMangleStaticRule(base uint32,
 			"Checking for EgressPolicy matched traffic",
 		},
 	})
-
 	if isEgressNode {
+		prerouting = append(prerouting, iptables.Rule{
+			Match:   iptables.MatchCriteria{}.MarkMatchesWithMask(base, Mark),
+			Action:  iptables.AcceptAction{},
+			Comment: []string{"EgressGateway traffic accept datapath rule"},
+		})
 		prerouting = append(prerouting, iptables.Rule{
 			Match:   iptables.MatchCriteria{},
 			Action:  iptables.JumpAction{Target: "EGRESSGATEWAY-REPLY-ROUTING"},

--- a/pkg/agent/police.go
+++ b/pkg/agent/police.go
@@ -847,6 +847,7 @@ func buildMangleStaticRule(base uint32,
 			"Checking for EgressPolicy matched traffic",
 		},
 	})
+
 	if isEgressNode {
 		prerouting = append(prerouting, iptables.Rule{
 			Match:   iptables.MatchCriteria{}.MarkMatchesWithMask(base, Mark),


### PR DESCRIPTION
### TL;DR.

The traffic of a pod running on an egress-gateway node `A` can't be properly tunnelled to an egress-gateway node `B`.

This is due to a combination of `iptables` rules in the `mangle` table and routing rules. 

### Analysis

On an egress-gateway node, the agent adds several `iptables` rules in the `PREROUTING` chain of the `mangle` table:
```
Chain PREROUTING (policy ACCEPT 12M packets, 1957M bytes)
 pkts bytes target     prot opt in     out     source               destination
    0     0 EGRESSGATEWAY-MARK-REQUEST  0    --  *      *       0.0.0.0/0            0.0.0.0/0            /* egw:Lh98b3mb9WlZrgw7 */ /* Checking for EgressPolicy matched traffic */
    0     0 EGRESSGATEWAY-REPLY-ROUTING  0    --  *      *       0.0.0.0/0            0.0.0.0/0            /* egw:sk3iZtUIsVFAPyMv */ /* EgressGateway reply datapath rule, rule is from the EgressGateway */
    0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            /* egw:TdWhJbzhP34YBgyK */ /* EgressGateway reply datapath rule, rule is from the EgressGateway */ mark match 0x26000000/0xff000000
```

Trying to tunnel traffic from a pod on this egress-gateway node (`A`) to another egress-gateway node (`B`) will trigger the following:
1. outbound traffic will first be marked with the tunnel mark for `B` in the `EGRESSGATEWAY-MARK-REQUEST` chain;
2. outbound traffic will then be processed by the `EGRESSGATEWAY-REPLY-ROUTING` chain, in which:
  * as the traffic is marked with the tunnel mark for `B`, it will be processed by the associated `CONNMARK` rule, *as if it were coming from `B` in order to exit through `A`*;
3. further iptables processing for is then stopped for the outbound traffic by the `ACCEPT` rule in the `PREROUTING` chain of the `mangle` table; 
4. outbound traffic will then be correctly routed to node `B` by routing rules matching the mark;
5. due to `CONNMARK` processing at step 2, return traffic coming from `B` **will then be processed by the `ctdir REPLY CONNMARK restore` rule**, which will restore `B`'s tunnel mark on the traffic;
6. return traffic is then **sent to the routing table associated with routing traffic to `B` by the routing rules, skipping `main` and `default` routing tables**, and then routed back in the tunnel (and probably dropped somewhere at this point).


This PR try to address this issue by adding an `ACCEPT` rule for marked trafic between the `EGRESSGATEWAY-MARK-REQUEST` and `EGRESSGATEWAY-REPLY-ROUTING` chains.

May fix:
* #1616
* #1782
* #1797 (partially, as this PR doesn't address the `rp_filter` sysctl issue)