### PR TITLE
Fix egress vxlan tunnel rp_filter not right

### DIFF
--- a/pkg/agent/vxlan/vxlan.go
+++ b/pkg/agent/vxlan/vxlan.go
@@ -5,14 +5,15 @@ package vxlan
 
 import (
 	"fmt"
-	"github.com/spidernet-io/egressgateway/pkg/ethtool"
-	wlock "github.com/spidernet-io/egressgateway/pkg/lock"
-	"github.com/vishvananda/netlink"
 	"io"
 	"net"
 	"os"
 	"reflect"
 	"syscall"
+
+	"github.com/spidernet-io/egressgateway/pkg/ethtool"
+	wlock "github.com/spidernet-io/egressgateway/pkg/lock"
+	"github.com/vishvananda/netlink"
 )
 
 // Device is vxlan device manager
@@ -89,7 +90,7 @@ func (dev *Device) EnsureLink(name string, vni int, port int, mac net.HardwareAd
 		return err
 	}
 
-	err = dev.ensureFilter(ipv4, ipv6)
+	err = dev.ensureFilter(name, ipv4, ipv6)
 	if err != nil {
 		return err
 	}
@@ -146,10 +147,9 @@ func (dev *Device) ensureLink(vxlan *netlink.Vxlan) (*netlink.Vxlan, error) {
 	return vxlan, nil
 }
 
-func (dev *Device) ensureFilter(ipv4, ipv6 *net.IPNet) error {
-	name := "all"
+func (dev *Device) ensureFilter(ifname string, ipv4, ipv6 *net.IPNet) error {
 	if ipv4 != nil {
-		err := writeProcSys(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/rp_filter", name), "0")
+		err := writeProcSys(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/rp_filter", ifname), "2")
 		if err != nil {
 			return err
 		}

--- a/pkg/agent/vxlan/vxlan_test.go
+++ b/pkg/agent/vxlan/vxlan_test.go
@@ -303,7 +303,7 @@ func Test_ensureFilter(t *testing.T) {
 	dev := new(Device)
 	patch := gomonkey.ApplyFuncReturn(writeProcSys, errors.New("some err"))
 	defer patch.Reset()
-	err := dev.ensureFilter(&net.IPNet{}, &net.IPNet{})
+	err := dev.ensureFilter("egress.vxlan", &net.IPNet{}, &net.IPNet{})
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
Fix: https://github.com/spidernet-io/egressgateway/issues/1797

For egress.vxlan, rp_filter needs to be set to 2. The rp_filter not only checks reply packets, but also checks incoming packets.

Because some systems default to 2 instead of 1, we have never encountered this issue. For example, Rocky defaults to 1, which can cause network connectivity problems.