### PR TITLE
ci: bump trivy-action from v0.33.1 to v0.35.0

### DIFF
--- a/.github/workflows/call-trivy.yaml
+++ b/.github/workflows/call-trivy.yaml
@@ -44,7 +44,7 @@ jobs:
       # merge to one step
       # https://github.com/aquasecurity/trivy-action/issues/313
       - name: Scan agent
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@0.35.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db
         with:
@@ -52,7 +52,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Scan controller
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@0.35.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db
         with:
@@ -60,7 +60,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Scan nettools
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@0.35.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db
         with:


### PR DESCRIPTION
```log
Error: Unable to resolve action `aquasecurity/trivy-action@0.33.1`, unable to find version `0.33.1`
```

Fix https://github.com/spidernet-io/egressgateway/issues/1933