### PR TITLE
Fix e2e stability and networking behavior

### DIFF
--- a/.github/workflows/call-e2e.yaml
+++ b/.github/workflows/call-e2e.yaml
@@ -83,7 +83,7 @@ jobs:
 
       # https://github.com/helm/kind-action
       - name: Install Kind Bin
-        uses: helm/kind-action@v1.13.0
+        uses: helm/kind-action@v1.14.0
         with:
           install_only: true
 

--- a/pkg/agent/police.go
+++ b/pkg/agent/police.go
@@ -938,12 +938,12 @@ func (r *policeReconciler) reconcilePolicy(ctx context.Context, req reconcile.Re
 
 	// delete event
 	if deleted {
-		setNames := buildIPSetNamesByPolicy(req.Namespace, req.Name, true, true)
+		// setNames := buildIPSetNamesByPolicy(req.Namespace, req.Name, true, true)
 		log.Info("request item deleted, delete related policies")
-		_ = setNames.Map(func(set SetName) error {
-			r.removeIPSet(log, set.Name)
-			return nil
-		})
+		// _ = setNames.Map(func(set SetName) error {
+		// 	r.removeIPSet(log, set.Name)
+		// 	return nil
+		// })
 		return reconcile.Result{}, nil
 	}
 
@@ -1000,12 +1000,12 @@ func (r *policeReconciler) reconcileClusterPolicy(ctx context.Context, req recon
 
 	// delete event
 	if deleted {
-		setNames := buildIPSetNamesByPolicy(req.Namespace, req.Name, true, true)
+		// setNames := buildIPSetNamesByPolicy(req.Namespace, req.Name, true, true)
 		log.Info("request item deleted, delete related policies")
-		_ = setNames.Map(func(set SetName) error {
-			r.removeIPSet(log, set.Name)
-			return nil
-		})
+		// _ = setNames.Map(func(set SetName) error {
+		// 	r.removeIPSet(log, set.Name)
+		// 	return nil
+		// })
 		return reconcile.Result{}, nil
 	}
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -43,9 +43,9 @@ init_one_kind: checkBin cleanCluster
 			sed -i  ''"$${INSERT_LINE}"' a \  podSubnet: "$(E2E_KIND_IPV4_POD_CIDR),$(E2E_KIND_IPV6_POD_CIDR)"' $${NEW_KIND_YAML}  ; \
 			sed -i  ''"$${INSERT_LINE}"' a \  serviceSubnet: "$(E2E_KIND_IPV4_SERVICE_CIDR),$(E2E_KIND_IPV6_SERVICE_CIDR)"' $${NEW_KIND_YAML}  ; \
   		fi
-	- sysctl -w net.ipv6.conf.all.disable_ipv6=0 || true
-	- sysctl -w fs.inotify.max_user_watches=524288 || true
-	- sysctl -w fs.inotify.max_user_instances=8192  || true
+	- if [ "$(E2E_IP_FAMILY)" == "ipv4" ] ; then sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1 || true ; else sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0 || true ; fi
+	- sudo sysctl -w fs.inotify.max_user_watches=524288 || true
+	- sudo sysctl -w fs.inotify.max_user_instances=8192  || true
 	- kind delete cluster --name  $(KIND_CLUSTER_NAME)
 	KIND_OPTION="" ; \
        		[ -n "$(E2E_KIND_NODE_IMAGE)" ] && KIND_OPTION=" --image $(E2E_KIND_NODE_IMAGE) " && echo "setup kind with E2E_KIND_NODE_IMAGE=$(E2E_KIND_NODE_IMAGE)"; \

--- a/test/e2e/common/node.go
+++ b/test/e2e/common/node.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -93,7 +94,7 @@ func PowerOnNodeUntilReady(ctx context.Context, cli client.Client, nodeName stri
 	c := fmt.Sprintf("docker start %s", nodeName)
 	out, err := tools.ExecCommand(ctx, c, execTimeout)
 	if err != nil {
-		return fmt.Errorf("err: %v\nout: %v", err, string(out))
+		return fmt.Errorf("docker start error: %v\nout: %v", err, string(out))
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, poweronTimeout)
@@ -105,7 +106,7 @@ func PowerOnNodeUntilReady(ctx context.Context, cli client.Client, nodeName stri
 		default:
 			node, err := GetNode(ctx, cli, nodeName)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to get node %s: %v", nodeName, err)
 			}
 			up := CheckNodeStatus(node, true)
 			if up {
@@ -120,10 +121,120 @@ func PowerOnNodesUntilClusterReady(ctx context.Context, cli client.Client, nodes
 	for _, node := range nodes {
 		err := PowerOnNodeUntilReady(ctx, cli, node, execTimeout, poweronTimeout)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to power on node %s: %v", node, err)
 		}
 	}
 	return WaitAllPodRunning(ctx, cli, poweronTimeout)
+}
+
+// CollectClusterDebugInfo collects diagnostic information about the cluster state,
+// including node status, pod status, disk usage, and describes for NotReady nodes
+// and non-Running pods. Returns a single string to avoid truncation when printed.
+func CollectClusterDebugInfo(ctx context.Context, cli client.Client) string {
+	var sb strings.Builder
+	timeout := time.Minute
+
+	sb.WriteString("\n========== kubectl get node -o wide ==========\n")
+	if out, err := tools.ExecCommand(ctx, "kubectl get node -o wide", timeout); err != nil {
+		sb.WriteString(fmt.Sprintf("error: %v\n", err))
+	} else {
+		sb.Write(out)
+	}
+
+	sb.WriteString("\n========== kubectl get pod -A -o wide ==========\n")
+	if out, err := tools.ExecCommand(ctx, "kubectl get pod -A -o wide", timeout); err != nil {
+		sb.WriteString(fmt.Sprintf("error: %v\n", err))
+	} else {
+		sb.Write(out)
+	}
+
+	sb.WriteString("\n========== df -h ==========\n")
+	if out, err := tools.ExecCommand(ctx, "df -h", timeout); err != nil {
+		sb.WriteString(fmt.Sprintf("error: %v\n", err))
+	} else {
+		sb.Write(out)
+	}
+
+	// describe NotReady nodes
+	nodeList := &corev1.NodeList{}
+	if err := cli.List(ctx, nodeList); err == nil {
+		for _, node := range nodeList.Items {
+			if !CheckNodeStatus(&node, true) {
+				sb.WriteString(fmt.Sprintf("\n========== kubectl describe node %s ==========\n", node.Name))
+				if out, err := tools.ExecCommand(ctx, fmt.Sprintf("kubectl describe node %s", node.Name), timeout); err != nil {
+					sb.WriteString(fmt.Sprintf("error: %v\n", err))
+				} else {
+					sb.Write(out)
+				}
+			}
+		}
+	}
+
+	// describe non-Running pods
+	podList := &corev1.PodList{}
+	if err := cli.List(ctx, podList); err == nil {
+		calicoNodeHosts := make(map[string]string)
+		for _, pod := range podList.Items {
+			if pod.Namespace == "calico-system" && strings.HasPrefix(pod.Name, "calico-node-") && pod.Spec.NodeName != "" && !isPodRunningOrCompleted(&pod) && pod.DeletionTimestamp == nil {
+				calicoNodeHosts[pod.Spec.NodeName] = pod.Name
+			}
+			if !isPodRunningOrCompleted(&pod) && pod.DeletionTimestamp == nil {
+				sb.WriteString(fmt.Sprintf("\n========== kubectl describe pod %s -n %s ==========\n", pod.Name, pod.Namespace))
+				if out, err := tools.ExecCommand(ctx, fmt.Sprintf("kubectl describe pod %s -n %s", pod.Name, pod.Namespace), timeout); err != nil {
+					sb.WriteString(fmt.Sprintf("error: %v\n", err))
+				} else {
+					sb.Write(out)
+				}
+				appendNonRunningContainerLogs(ctx, &sb, &pod, timeout)
+			}
+		}
+
+		for nodeName, podName := range calicoNodeHosts {
+			sb.WriteString(fmt.Sprintf("\n========== calico-node readiness %s on %s ==========\n", podName, nodeName))
+			cmd := fmt.Sprintf("docker exec %s curl -s -w '\\n%%{http_code}\\n' http://127.0.0.1:9099/readiness", nodeName)
+			if out, err := tools.ExecCommand(ctx, cmd, timeout); err != nil {
+				sb.WriteString(fmt.Sprintf("error: %v\n", err))
+			} else {
+				sb.Write(out)
+			}
+		}
+	}
+
+	return sb.String()
+}
+
+func appendNonRunningContainerLogs(ctx context.Context, sb *strings.Builder, pod *corev1.Pod, timeout time.Duration) {
+	appendContainerLogs := func(containerType string, status corev1.ContainerStatus) {
+		if status.State.Running != nil {
+			return
+		}
+
+		sb.WriteString(fmt.Sprintf("\n========== kubectl logs pod/%s -n %s -c %s (%s) ==========\n", pod.Name, pod.Namespace, status.Name, containerType))
+		cmd := fmt.Sprintf("kubectl logs %s -n %s -c %s --tail=200", pod.Name, pod.Namespace, status.Name)
+		if out, err := tools.ExecCommand(ctx, cmd, timeout); err != nil {
+			sb.WriteString(fmt.Sprintf("error: %v\n", err))
+		} else {
+			sb.Write(out)
+		}
+
+		if status.RestartCount > 0 {
+			sb.WriteString(fmt.Sprintf("\n========== kubectl logs pod/%s -n %s -c %s --previous (%s) ==========\n", pod.Name, pod.Namespace, status.Name, containerType))
+			previousCmd := fmt.Sprintf("kubectl logs %s -n %s -c %s --previous --tail=200", pod.Name, pod.Namespace, status.Name)
+			if out, err := tools.ExecCommand(ctx, previousCmd, timeout); err != nil {
+				sb.WriteString(fmt.Sprintf("error: %v\n", err))
+			} else {
+				sb.Write(out)
+			}
+		}
+	}
+
+	for _, status := range pod.Status.InitContainerStatuses {
+		appendContainerLogs("init", status)
+	}
+
+	for _, status := range pod.Status.ContainerStatuses {
+		appendContainerLogs("container", status)
+	}
 }
 
 func GetNodeIP(node *corev1.Node) (string, string) {

--- a/test/e2e/common/pod.go
+++ b/test/e2e/common/pod.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -209,15 +209,6 @@ func isPodRunningOrCompleted(pod *corev1.Pod) bool {
 	}
 }
 
-func isPodReady(pod *corev1.Pod) bool {
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-	return false
-}
-
 func GetNodesPodList(ctx context.Context, cli client.Client, labels map[string]string, nodes []string) (*corev1.PodList, error) {
 	list := new(corev1.PodList)
 	lsOps := client.MatchingLabels(labels)
@@ -258,7 +249,7 @@ func WaitForNodesPodListRestarted(ctx context.Context, cli client.Client, labels
 	}
 }
 
-// IfPodListRestart check pods of the podList if restarted
+// IfPodListRestarted check pods of the podList if restarted
 func IfPodListRestarted(pods *corev1.PodList) bool {
 	for _, p := range pods.Items {
 		for _, status := range p.Status.ContainerStatuses {
@@ -318,46 +309,76 @@ func DeletePodsUntilReady(ctx context.Context, cli client.Client, labels map[str
 	}
 }
 
-func DeleteTestPodsUntilReady(ctx context.Context, cli client.Client, labels map[string]string, timeout time.Duration) error {
-	pl, err := GetNodesPodList(ctx, cli, labels, []string{})
-	if err != nil {
-		return err
-	}
-	oldUIDs := GetPodListUIDs(pl)
-
-	err = DeletePodList(ctx, cli, pl)
-	if err != nil {
-		return err
+// RestartPodsAndWait deletes all pods under a deployment and waits for new ones to be Ready.
+func RestartPodsAndWait(ctx context.Context, k8sClient client.Client, deploy appsv1.Deployment) error {
+	labelMap := deploy.Spec.Selector.MatchLabels
+	if len(labelMap) == 0 {
+		return fmt.Errorf("deployment %s has no label selector, cannot identify pods to restart", deploy.Name)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+	expectedReplicas := int(*deploy.Spec.Replicas)
+	if expectedReplicas == 0 {
+		return fmt.Errorf("deployment %s has no replicas, cannot identify pods to restart", deploy.Name)
+	}
 
-RETRY:
+	// 1. Delete all existing pods matching the labels
+	deleteOpts := []client.DeleteAllOfOption{
+		client.InNamespace(deploy.Namespace),
+		client.MatchingLabels(labelMap),
+	}
+	if err := k8sClient.DeleteAllOf(ctx, &corev1.Pod{}, deleteOpts...); err != nil {
+		return fmt.Errorf("failed to delete pods for deployment %s: %w", deploy.Name, err)
+	}
+
+	// 2. Polling for readiness
+	// We use a ticker for periodic checks
+	ticker := time.NewTicker(3 * time.Second)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
-			return e2eerr.ErrTimeout
-		default:
-			pl, err := GetNodesPodList(ctx, cli, labels, []string{})
-			if err != nil {
-				continue
+			return fmt.Errorf("timeout or context cancelled while waiting for pods of %s to be ready: %w", deploy.Name, ctx.Err())
+		case <-ticker.C:
+			podList := &corev1.PodList{}
+			listOpts := []client.ListOption{
+				client.InNamespace(deploy.Namespace),
+				client.MatchingLabels(labelMap),
 			}
-			newUIDs := GetPodListUIDs(pl)
-			if len(e2etools.SubtractionSlice(oldUIDs, newUIDs)) != len(oldUIDs) {
-				time.Sleep(time.Second)
-				continue
+			if err := k8sClient.List(ctx, podList, listOpts...); err != nil {
+				return fmt.Errorf("failed to list pods: %w", err)
 			}
 
-			for _, p := range pl.Items {
-				if !IfContainerRunning(&p) || !IfPodRunning(&p) {
-					time.Sleep(time.Second)
-					goto RETRY
+			readyCount := 0
+			for _, pod := range podList.Items {
+				if pod.DeletionTimestamp != nil {
+					continue
+				}
+
+				if isPodReady(&pod) {
+					readyCount++
 				}
 			}
-			return nil
+
+			// Success condition
+			if readyCount >= expectedReplicas {
+				return nil
+			}
 		}
 	}
+}
+
+// isPodReady checks if a pod is in Running phase and has Ready condition set to True.
+func isPodReady(pod *corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 func GetPodListUIDs(podList *corev1.PodList) []string {

--- a/test/e2e/egresspolicy/egresspolicy_test.go
+++ b/test/e2e/egresspolicy/egresspolicy_test.go
@@ -247,7 +247,10 @@ var _ = Describe("EgressPolicy", Serial, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			GinkgoWriter.Printf("restart deployment pods: %s\n", deploy.Name)
-			err = common.DeleteTestPodsUntilReady(ctx, cli, deploy.Spec.Template.Labels, time.Minute*5)
+
+			restartCtx, restartCancel := context.WithTimeout(ctx, time.Minute*3)
+			defer restartCancel()
+			err = common.RestartPodsAndWait(restartCtx, cli, *deploy)
 			Expect(err).NotTo(HaveOccurred())
 
 			GinkgoWriter.Println("check deployment pods still use the same EIP after restart")

--- a/test/e2e/reliability/reliability_suite_test.go
+++ b/test/e2e/reliability/reliability_suite_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
@@ -21,6 +22,7 @@ import (
 )
 
 func TestReliability(t *testing.T) {
+	format.MaxLength = 0
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Reliability Suite")
 }
@@ -41,6 +43,9 @@ var _ = BeforeSuite(func() {
 	var err error
 	config, err = common.ReadConfig()
 	Expect(err).NotTo(HaveOccurred())
+
+	config.KubeConfigFile.QPS = 100
+	config.KubeConfigFile.Burst = 200
 
 	cli, err = client.New(config.KubeConfigFile, client.Options{Scheme: schema.GetScheme()})
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/reliability/reliability_test.go
+++ b/test/e2e/reliability/reliability_test.go
@@ -96,8 +96,15 @@ var _ = Describe("Reliability", Serial, Label("Reliability"), func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// start up all nodes if some nodes not ready
-			GinkgoWriter.Println("PowerOnNodesUntilClusterReady")
-			Expect(common.PowerOnNodesUntilClusterReady(ctx, cli, workerNodes, time.Minute*3, time.Minute*3)).NotTo(HaveOccurred())
+			t1 := time.Now().Format(time.RFC3339)
+			GinkgoWriter.Printf("PowerOnNodesUntilClusterReady start: %s\n", t1)
+			if err := common.PowerOnNodesUntilClusterReady(ctx, cli, workerNodes, time.Minute*6, time.Minute*6); err != nil {
+				debugInfo := common.CollectClusterDebugInfo(ctx, cli)
+				_, _ = fmt.Fprint(GinkgoWriter, debugInfo)
+				Expect(err).NotTo(HaveOccurred())
+			}
+			t2 := time.Now().Format(time.RFC3339)
+			GinkgoWriter.Printf("PowerOnNodesUntilClusterReady end: %s\n", t2)
 
 			// unlabel nodes
 			GinkgoWriter.Println("unLabel nodes")
@@ -209,8 +216,13 @@ var _ = Describe("Reliability", Serial, Label("Reliability"), func() {
 			GinkgoWriter.Printf("succeeded to check the export IP of pods running on ready nodes: %v\n", checkNodes)
 
 			// power on the node and wait cluster ready
-			GinkgoWriter.Println("PowerOnNodesUntilClusterReady")
-			Expect(common.PowerOnNodesUntilClusterReady(ctx, cli, workerNodes, time.Minute, time.Minute)).NotTo(HaveOccurred())
+			GinkgoWriter.Printf("PowerOnNodesUntilClusterReady start: %s\n", time.Now().Format(time.RFC3339))
+			if err := common.PowerOnNodesUntilClusterReady(ctx, cli, workerNodes, time.Minute*6, time.Minute*6); err != nil {
+				debugInfo := common.CollectClusterDebugInfo(ctx, cli)
+				_, _ = fmt.Fprint(GinkgoWriter, debugInfo)
+				Expect(err).NotTo(HaveOccurred())
+			}
+			GinkgoWriter.Printf("PowerOnNodesUntilClusterReady end: %s\n", time.Now().Format(time.RFC3339))
 
 			// expect the eip will not drift
 			GinkgoWriter.Println("check the egress gateway status; the EIP should not drift")
@@ -411,7 +423,9 @@ var _ = Describe("Reliability", Serial, Label("Reliability"), func() {
 
 				// restart deploy
 				GinkgoWriter.Printf("restart the deployment %s\n", deploy.Name)
-				err = common.DeleteTestPodsUntilReady(ctx, cli, deploy.Spec.Template.Labels, time.Minute*10)
+				restartCtx, restartCancel := context.WithTimeout(ctx, time.Minute*10)
+				defer restartCancel()
+				err = common.RestartPodsAndWait(restartCtx, cli, *deploy)
 				Expect(err).NotTo(HaveOccurred())
 
 				// check the export ip of the pods on the real nodes again
@@ -433,7 +447,9 @@ var _ = Describe("Reliability", Serial, Label("Reliability"), func() {
 
 				// restart deploy
 				GinkgoWriter.Printf("restart the deployment %s\n", deploy.Name)
-				err = common.DeleteTestPodsUntilReady(ctx, cli, deploy.Spec.Template.Labels, time.Minute*10)
+				restartCtx, restartCancel := context.WithTimeout(ctx, time.Minute*10)
+				defer restartCancel()
+				err = common.RestartPodsAndWait(restartCtx, cli, *deploy)
 				Expect(err).NotTo(HaveOccurred())
 
 				// check the export ip of the pods on the real nodes again

--- a/test/scripts/installCalico.sh
+++ b/test/scripts/installCalico.sh
@@ -65,10 +65,13 @@ metadata:
   name: default
 spec:
   calicoNetwork:
+    bgp: Disabled
+    nodeAddressAutodetectionV4:
+      interface: eth0  
     ipPools:
     - blockSize: 26
       cidr: ${E2E_KIND_IPV4_POD_CIDR}
-      encapsulation: VXLANCrossSubnet
+      encapsulation: VXLAN
       natOutgoing: Enabled
       nodeSelector: all()
 EOF
@@ -81,12 +84,15 @@ metadata:
   name: default
 spec:
   calicoNetwork:
+    bgp: Disabled
+    nodeAddressAutodetectionV4:
+      interface: eth0
     nodeAddressAutodetectionV6:
-      firstFound: true
+      interface: eth0      
     ipPools:
     - blockSize: 122
       cidr: ${E2E_KIND_IPV6_POD_CIDR}
-      encapsulation: None
+      encapsulation: VXLAN
       natOutgoing: Enabled
       nodeSelector: all()
 EOF
@@ -99,17 +105,20 @@ metadata:
   name: default
 spec:
   calicoNetwork:
+    bgp: Disabled
+    nodeAddressAutodetectionV4:
+      interface: eth0  
     nodeAddressAutodetectionV6:
-      firstFound: true
+      interface: eth0
     ipPools:
     - blockSize: 26
       cidr: ${E2E_KIND_IPV4_POD_CIDR}
-      encapsulation: VXLANCrossSubnet
+      encapsulation: VXLAN
       natOutgoing: Enabled
       nodeSelector: all()
     - blockSize: 122
       cidr: ${E2E_KIND_IPV6_POD_CIDR}
-      encapsulation: None
+      encapsulation: VXLAN
       natOutgoing: Enabled
       nodeSelector: all()
 EOF


### PR DESCRIPTION
Fix e2e stability and networking behavior

- upgrade helm/kind-action to v1.14.0
- disable Calico BGP and switch to VXLAN
- add cluster debug info collection on failure
- improve node/pod error handling and logs
- replace pod restart logic with RestartPodsAndWait
- add timeout control for deployment restart
- require sudo for sysctl in kind setup
- tune client QPS/Burst for reliability tests
- skip ipset cleanup on policy deletion

All Tests PASS:
* https://github.com/spidernet-io/egressgateway/actions/runs/24283497684