### PR TITLE
fix(route): guard EnsureRoute calls in Ensure() against nil IP

### DIFF
--- a/pkg/agent/route/route.go
+++ b/pkg/agent/route/route.go
@@ -111,13 +111,17 @@ func (r *RuleRoute) Ensure(linkName string, ipv4, ipv6 *net.IP, table int, mark 
 
 	log.V(1).Info("get link")
 
-	err = r.EnsureRoute(link, ipv4, netlink.FAMILY_V4, table, log)
-	if err != nil {
-		return err
+	if ipv4 != nil {
+		err = r.EnsureRoute(link, ipv4, netlink.FAMILY_V4, table, log)
+		if err != nil {
+			return err
+		}
 	}
-	err = r.EnsureRoute(link, ipv6, netlink.FAMILY_V6, table, log)
-	if err != nil {
-		return err
+	if ipv6 != nil {
+		err = r.EnsureRoute(link, ipv6, netlink.FAMILY_V6, table, log)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem

In `pkg/agent/route/route.go`, the `Ensure()` function correctly guards `EnsureRule` behind nil-checks for `ipv4`/`ipv6`, but calls `EnsureRoute` unconditionally — even when both are `nil`.

`EnsureRoute` with `ip == nil` iterates all routes in the given policy-routing table and deletes every route whose `Gw` doesn't match `ip`. Since `ip == nil` makes the condition `ip == nil || route.Gw.String() != ip.String()` always true, **all routes in the table are wiped** before the function returns.

This is triggered by `keepVXLAN` (every 10s) when iterating `peerMap` entries whose tunnel IP is not yet populated — a race condition between `reconcileEgressTunnel` and `keepVXLAN` at agent startup or after node restart.

**Effect**: cross-node VXLAN tunnel routes added by `reconcileEgressGateway` are deleted within 10 seconds of creation, permanently breaking cross-node egress routing. Reproducible on any multi-node cluster with `EgressGateway` CRDs configured.

## Root cause

```go
// Ensure() — EnsureRule is correctly guarded:
if ipv4 != nil {
    err := r.EnsureRule(netlink.FAMILY_V4, table, mark, log)
}

// EnsureRoute is NOT guarded (bug):
err = r.EnsureRoute(link, ipv4, netlink.FAMILY_V4, table, log)  // ipv4 may be nil
err = r.EnsureRoute(link, ipv6, netlink.FAMILY_V6, table, log)  // ipv6 may be nil
```

## Fix

Apply the same nil-guard pattern already used for `EnsureRule`:

```go
if ipv4 != nil {
    err = r.EnsureRoute(link, ipv4, netlink.FAMILY_V4, table, log)
    if err != nil {
        return err
    }
}
if ipv6 != nil {
    err = r.EnsureRoute(link, ipv6, netlink.FAMILY_V6, table, log)
    if err != nil {
        return err
    }
}
```

When the peer tunnel IP is not yet known, `EnsureRoute` is skipped for that address family instead of wiping the table. Existing cross-node routes are preserved until the peer IP becomes available on the next reconcile cycle.

## Testing

Tested on a 3-node k3s cluster (v1.35.4+k3s1) with one `EgressGateway` per node and `EgressClusterPolicies` using per-site `destSubnet`. Before the fix, cross-node VXLAN routes were deleted every ~10s (confirmed via `ip route show table <fwmark>` and agent logs showing `delete route`). After the fix, routes remain stable across multiple keepVXLAN cycles (verified over 36s / 3+ cycles with no `delete route` log entries).

---

> **Note**: This fix was created with the assistance of [Claude Code](https://claude.ai/code) (model: `claude-sonnet-4-6` by Anthropic) following manual root-cause analysis and live verification on a homelab k3s cluster.