### PR TITLE
fix(agent): use byte-mask in nat/POSTROUTING accept rule to match per-gateway marks

### DIFF
--- a/pkg/agent/police.go
+++ b/pkg/agent/police.go
@@ -600,7 +600,7 @@ func buildNatStaticRule(base uint32) map[string][]iptables.Rule {
 			},
 		},
 		{
-			Match:  iptables.MatchCriteria{}.MarkMatchesWithMask(base, Mask),
+			Match:  iptables.MatchCriteria{}.MarkMatchesWithMask(base, Mark),
 			Action: iptables.AcceptAction{},
 			Comment: []string{
 				"Accept for egress traffic from pod going to EgressTunnel",


### PR DESCRIPTION
## Problem

In `pkg/agent/police.go`, `buildNatStaticRule()` inserts an ACCEPT rule in `nat/POSTROUTING` designed to bypass the CNI masquerade rule (Flannel's `FLANNEL-POSTRTG`, Calico, etc.) for traffic already handled by EgressGateway. This rule uses the wrong mask constant:

```go
Match: iptables.MatchCriteria{}.MarkMatchesWithMask(base, Mask),  // Mask = 0xffffffff
```

With `Mask = 0xffffffff`, the rule generates:

```text
-m mark --mark 0x26000000/0xffffffff
```

This is an **exact 32-bit match** — it only fires if the packet mark equals `base` exactly (e.g. `0x26000000`). In cross-node setups the agent stamps a **per-gateway-node mark** derived from `node.Status.Mark` via `parseMark()`, resulting in values like `0x26577c9e` or `0x26df9c4e` (high byte = base high byte, low 3 bytes from a hash of the node). These marks never equal the base mark exactly, so **the ACCEPT rule is effectively dead on any non-gateway node**.

The packet then falls through to the CNI masquerade rule, gets SNAT'd to the local VXLAN tunnel address (e.g. `172.31.0.185`), and arrives on the gateway node with the wrong source IP. The ipset `egress-src-v4-*` no longer matches, the EgressGateway SNAT in `EGRESSGATEWAY-SNAT-EIP` is skipped, and the connection exits with the source node's public IP instead of the EIP.

**Effect**: cross-node egress SNAT is silently broken on any cluster where the CNI applies MASQUERADE (Flannel VXLAN, some Calico configurations). Pods on non-gateway nodes reach the Internet with the wrong source IP; reverse traffic is unreachable or routed incorrectly.

## Root cause

The constant `Mask = 0xffffffff` was used where `Mark = 0xff000000` was intended — a one-character typo never caught because existing tests only exercise the pod-on-gateway-node path.

The same file already uses `Mark` (the correct byte mask) everywhere else:

| Function | Chain | Mask used |
|---|---|---|
| `buildMangleStaticRule` | `PREROUTING` | `Mark` = `0xff000000` ✓ |
| `buildFilterStaticRule` | `FORWARD` | `Mark` ✓ |
| `buildNatStaticRule` | `PREROUTING` | `Mark` ✓ |
| **`buildNatStaticRule`** | **`POSTROUTING` ACCEPT** | **`Mask` = `0xffffffff` ✗** |

## Fix

One line change in `pkg/agent/police.go`, `buildNatStaticRule()`:

```diff
-Match: iptables.MatchCriteria{}.MarkMatchesWithMask(base, Mask),
+Match: iptables.MatchCriteria{}.MarkMatchesWithMask(base, Mark),
```

The rule now renders as:

```text
-m mark --mark 0x26000000/0xff000000
```

This matches any packet whose top byte equals the base high byte, which is true for all per-gateway-node marks regardless of the low 3 bytes. No change to insertion order is needed: the ACCEPT rule already sits after `EGRESSGATEWAY-SNAT-EIP` (gateway node's own SNAT fires first) and before `KUBE-POSTROUTING`/`FLANNEL-POSTRTG`.

## Testing

Validated on a 3-node k3s cluster (Flannel VXLAN, `useNodeIP: true`) with one `EgressGateway` per site and cross-node egress policies. The equivalent iptables rule was first applied manually on each node:

```bash
iptables -t nat -I POSTROUTING 2 \
  -m mark --mark 0x26000000/0xff000000 -j ACCEPT \
  -m comment --comment "egw-flannel-bypass-workaround"
```

Results measured live before vs. after:

| Metric | Before | After |
|---|---|---|
| MASQUERADE counter on gateway node | 0 packets | 5+ packets |
| Conntrack reply destination | `172.31.0.185` (tunnel) | `10.1.2.30` (gateway IP) |
| Connection state | `UNREPLIED` | `ESTABLISHED [ASSURED]` |
| Pod public IP (5/5 curls) | source node IP | gateway node IP ✓ |

---

> **Note**: This fix was created with the assistance of [Claude Code](https://claude.ai/code) (model: `claude-sonnet-4-6` by Anthropic) following manual root-cause analysis and live verification on a homelab k3s cluster.