### PR TITLE
fix: detect Kubernetes Node Pod CIDRs in auto and k8s modes

### DIFF
--- a/pkg/controller/clusterinfo/clusterinfo.go
+++ b/pkg/controller/clusterinfo/clusterinfo.go
@@ -146,8 +146,10 @@ func (r *clusterInfo) reconcileNode(ctx context.Context, req reconcile.Request, 
 		log.Info("not found default EgressClusterInfo")
 		return nil
 	}
-	// skip if not enable detect node
-	if !info.Spec.AutoDetect.NodeIP {
+	detectNodeIP := info.Spec.AutoDetect.NodeIP
+	detectK8sPodCIDR := info.Spec.AutoDetect.PodCidrMode == egressv1.CniTypeK8s ||
+		info.Spec.AutoDetect.PodCidrMode == egressv1.CniTypeAuto
+	if !detectNodeIP && !detectK8sPodCIDR {
 		return nil
 	}
 
@@ -161,51 +163,71 @@ func (r *clusterInfo) reconcileNode(ctx context.Context, req reconcile.Request, 
 		deleted = true
 	}
 	deleted = deleted || !node.GetDeletionTimestamp().IsZero()
+	changed := false
 
 	if deleted {
 		log.Info("delete event of node", "delete", req.Name)
-		if _, ok := info.Status.NodeIP[req.Name]; ok {
-			delete(info.Status.NodeIP, req.Name)
-			err := r.cli.Status().Update(ctx, info)
-			if err != nil {
-				return fmt.Errorf("failed to update EgressClusterInfo when delete node(%s) event: %w", node.Name, err)
+		if detectNodeIP {
+			if _, ok := info.Status.NodeIP[req.Name]; ok {
+				delete(info.Status.NodeIP, req.Name)
+				changed = true
+			}
+		}
+		if detectK8sPodCIDR {
+			if _, ok := info.Status.PodCIDR[req.Name]; ok {
+				delete(info.Status.PodCIDR, req.Name)
+				changed = true
 			}
 		}
 	} else {
 		log.Info("update event of node", "update", req.Name)
-		ipv4, ipv6 := getNodeIPList(node)
-
-		if info.Status.NodeIP == nil {
-			info.Status.NodeIP = make(map[string]egressv1.IPListPair)
+		if detectNodeIP {
+			ipv4, ipv6 := getNodeIPList(node)
+			if info.Status.NodeIP == nil {
+				info.Status.NodeIP = make(map[string]egressv1.IPListPair)
+			}
+			if updateIPListPair(info.Status.NodeIP, req.Name, ipv4, ipv6) {
+				changed = true
+			}
 		}
 
-		if val, ok := info.Status.NodeIP[req.Name]; ok {
-			// diff info.Status.NodeIP[req.Name].IPv4 == ipv4
-			// diff info.Status.NodeIP[req.Name].IPv6 == ipv6
-			if !utils.EqualStringSlice(val.IPv4, ipv4) ||
-				!utils.EqualStringSlice(val.IPv6, ipv6) {
-				// then update info.Status.NodeIP[req.Name]
-				info.Status.NodeIP[req.Name] = egressv1.IPListPair{
-					IPv4: ipv4,
-					IPv6: ipv6,
-				}
-				err := r.cli.Status().Update(ctx, info)
-				if err != nil {
-					return fmt.Errorf("failed to update EgressClusterInfo when update node(%s) event: %w", node.Name, err)
-				}
+		if detectK8sPodCIDR {
+			ipv4, ipv6 := getNodePodCIDRList(node)
+			if info.Status.PodCIDR == nil {
+				info.Status.PodCIDR = make(map[string]egressv1.IPListPair)
 			}
-		} else {
-			info.Status.NodeIP[req.Name] = egressv1.IPListPair{
-				IPv4: ipv4,
-				IPv6: ipv6,
-			}
-			err := r.cli.Status().Update(ctx, info)
-			if err != nil {
-				return fmt.Errorf("failed to update EgressClusterInfo when update node(%s) event: %w", node.Name, err)
+			if len(ipv4) == 0 && len(ipv6) == 0 {
+				if _, ok := info.Status.PodCIDR[req.Name]; ok {
+					delete(info.Status.PodCIDR, req.Name)
+					changed = true
+				}
+			} else if updateIPListPair(info.Status.PodCIDR, req.Name, ipv4, ipv6) {
+				changed = true
 			}
 		}
 	}
+
+	if changed {
+		err := r.cli.Status().Update(ctx, info)
+		if err != nil {
+			return fmt.Errorf("failed to update EgressClusterInfo when reconciling node(%s): %w", req.Name, err)
+		}
+	}
 	return nil
+}
+
+func updateIPListPair(items map[string]egressv1.IPListPair, name string, ipv4, ipv6 []string) bool {
+	if val, ok := items[name]; ok {
+		if utils.EqualStringSlice(val.IPv4, ipv4) && utils.EqualStringSlice(val.IPv6, ipv6) {
+			return false
+		}
+	}
+
+	items[name] = egressv1.IPListPair{
+		IPv4: ipv4,
+		IPv6: ipv6,
+	}
+	return true
 }
 
 func (r *clusterInfo) reconcileCalicoIPPool(ctx context.Context, req reconcile.Request, log logr.Logger) error {
@@ -373,7 +395,12 @@ func (p nodePredicate) Update(updateEvent event.UpdateEvent) bool {
 
 	oldV4, oldV6 := getNodeIPList(oldObj)
 	newV4, newV6 := getNodeIPList(newObj)
-	if utils.EqualStringSlice(oldV4, newV4) && utils.EqualStringSlice(oldV6, newV6) {
+	oldPodV4, oldPodV6 := getNodePodCIDRList(oldObj)
+	newPodV4, newPodV6 := getNodePodCIDRList(newObj)
+	if utils.EqualStringSlice(oldV4, newV4) &&
+		utils.EqualStringSlice(oldV6, newV6) &&
+		utils.EqualStringSlice(oldPodV4, newPodV4) &&
+		utils.EqualStringSlice(oldPodV6, newPodV6) {
 		return false
 	}
 	return true

--- a/pkg/controller/clusterinfo/clusterinfo.go
+++ b/pkg/controller/clusterinfo/clusterinfo.go
@@ -173,12 +173,6 @@ func (r *clusterInfo) reconcileNode(ctx context.Context, req reconcile.Request, 
 				changed = true
 			}
 		}
-		if detectK8sPodCIDR {
-			if _, ok := info.Status.PodCIDR[req.Name]; ok {
-				delete(info.Status.PodCIDR, req.Name)
-				changed = true
-			}
-		}
 	} else {
 		log.Info("update event of node", "update", req.Name)
 		if detectNodeIP {
@@ -190,21 +184,14 @@ func (r *clusterInfo) reconcileNode(ctx context.Context, req reconcile.Request, 
 				changed = true
 			}
 		}
+	}
 
-		if detectK8sPodCIDR {
-			ipv4, ipv6 := getNodePodCIDRList(node)
-			if info.Status.PodCIDR == nil {
-				info.Status.PodCIDR = make(map[string]egressv1.IPListPair)
-			}
-			if len(ipv4) == 0 && len(ipv6) == 0 {
-				if _, ok := info.Status.PodCIDR[req.Name]; ok {
-					delete(info.Status.PodCIDR, req.Name)
-					changed = true
-				}
-			} else if updateIPListPair(info.Status.PodCIDR, req.Name, ipv4, ipv6) {
-				changed = true
-			}
+	if detectK8sPodCIDR {
+		podCIDRChanged, err := r.syncPodCIDRs(ctx, info)
+		if err != nil {
+			return err
 		}
+		changed = changed || podCIDRChanged
 	}
 
 	if changed {
@@ -249,58 +236,13 @@ func (r *clusterInfo) reconcileCalicoIPPool(ctx context.Context, req reconcile.R
 		return nil
 	}
 
-	deleted := false
-	pool := new(calicov1.IPPool)
-	err = r.cli.Get(ctx, req.NamespacedName, pool)
+	changed, err := r.syncPodCIDRs(ctx, info)
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
-		deleted = true
+		return err
 	}
-	deleted = deleted || !pool.GetDeletionTimestamp().IsZero()
-
-	if deleted {
-		log.Info("delete event of CalicoIPPool", "delete", req.Name)
-		if _, ok := info.Status.PodCIDR[req.Name]; ok {
-			delete(info.Status.PodCIDR, req.Name)
-			err := r.cli.Status().Update(ctx, info)
-			if err != nil {
-				return fmt.Errorf("failed to update EgressClusterInfo when delete CalicoIPPool(%s) event: %w", pool.Name, err)
-			}
-		}
-	} else {
-		log.Info("update event of CalicoIPPool", "update", req.Name)
-		ipv4, ipv6 := getCalicoIPPoolList(pool)
-
-		if info.Status.PodCIDR == nil {
-			info.Status.PodCIDR = make(map[string]egressv1.IPListPair)
-		}
-
-		if val, ok := info.Status.PodCIDR[req.Name]; ok {
-			// diff info.Status.PodCIDR[req.Name].IPv4 == ipv4
-			// diff info.Status.PodCIDR[req.Name].IPv6 == ipv6
-			if !utils.EqualStringSlice(val.IPv4, ipv4) ||
-				!utils.EqualStringSlice(val.IPv6, ipv6) {
-				// then update info.Status.PodCIDR[req.Name]
-				info.Status.PodCIDR[req.Name] = egressv1.IPListPair{
-					IPv4: ipv4,
-					IPv6: ipv6,
-				}
-				err := r.cli.Status().Update(ctx, info)
-				if err != nil {
-					return fmt.Errorf("failed to update EgressClusterInfo when update CalicoIPPool(%s) event: %w", pool.Name, err)
-				}
-			}
-		} else {
-			info.Status.PodCIDR[req.Name] = egressv1.IPListPair{
-				IPv4: ipv4,
-				IPv6: ipv6,
-			}
-			err := r.cli.Status().Update(ctx, info)
-			if err != nil {
-				return fmt.Errorf("failed to update EgressClusterInfo when update CalicoIPPool(%s) event: %w", pool.Name, err)
-			}
+	if changed {
+		if err := r.cli.Status().Update(ctx, info); err != nil {
+			return fmt.Errorf("failed to update EgressClusterInfo when reconciling CalicoIPPool(%s): %w", req.Name, err)
 		}
 	}
 
@@ -331,15 +273,121 @@ func (r *clusterInfo) reconcileInfo(ctx context.Context, req reconcile.Request, 
 		}
 
 		log.Info("update event of EgressClusterInfo", "update", req.Name)
+		changed := false
 		if !utils.EqualStringSlice(info.Spec.ExtraCidr, info.Status.ExtraCidr) {
 			info.Status.ExtraCidr = info.Spec.ExtraCidr
+			changed = true
+		}
+
+		podCIDRChanged, err := r.syncPodCIDRs(ctx, info)
+		if err != nil {
+			return err
+		}
+		changed = changed || podCIDRChanged
+
+		if changed {
 			err := r.cli.Status().Update(ctx, info)
 			if err != nil {
-				return fmt.Errorf("failed to update EgressClusterInfo when update ExtraCidr: %w", err)
+				return fmt.Errorf("failed to update EgressClusterInfo status: %w", err)
 			}
 		}
 	}
 	return nil
+}
+
+func (r *clusterInfo) syncPodCIDRs(ctx context.Context, info *egressv1.EgressClusterInfo) (bool, error) {
+	mode, podCIDRs, err := r.resolvePodCIDRs(ctx, info.Spec.AutoDetect.PodCidrMode)
+	if err != nil {
+		return false, err
+	}
+
+	changed := false
+	if info.Status.PodCidrMode != mode {
+		info.Status.PodCidrMode = mode
+		changed = true
+	}
+	if !equalIPListPairMap(info.Status.PodCIDR, podCIDRs) {
+		info.Status.PodCIDR = podCIDRs
+		changed = true
+	}
+
+	return changed, nil
+}
+
+func (r *clusterInfo) resolvePodCIDRs(ctx context.Context, configuredMode egressv1.PodCidrMode) (egressv1.PodCidrMode, map[string]egressv1.IPListPair, error) {
+	switch configuredMode {
+	case egressv1.CniTypeEmpty:
+		return egressv1.CniTypeEmpty, nil, nil
+	case egressv1.CniTypeK8s:
+		podCIDRs, err := r.listK8sPodCIDRs(ctx)
+		return egressv1.CniTypeK8s, podCIDRs, err
+	case egressv1.CniTypeCalico:
+		podCIDRs, _, err := r.listCalicoPodCIDRs(ctx)
+		return egressv1.CniTypeCalico, podCIDRs, err
+	case egressv1.CniTypeAuto:
+		podCIDRs, poolCount, err := r.listCalicoPodCIDRs(ctx)
+		if err == nil && poolCount > 0 {
+			return egressv1.CniTypeCalico, podCIDRs, nil
+		}
+		if err != nil && !meta.IsNoMatchError(err) {
+			return egressv1.CniTypeEmpty, nil, fmt.Errorf("failed to auto-detect Calico Pod CIDRs: %w", err)
+		}
+
+		podCIDRs, err = r.listK8sPodCIDRs(ctx)
+		return egressv1.CniTypeK8s, podCIDRs, err
+	default:
+		return egressv1.CniTypeEmpty, nil, fmt.Errorf("unsupported Pod CIDR mode %q", configuredMode)
+	}
+}
+
+func (r *clusterInfo) listK8sPodCIDRs(ctx context.Context) (map[string]egressv1.IPListPair, error) {
+	nodes := new(corev1.NodeList)
+	if err := r.cli.List(ctx, nodes); err != nil {
+		return nil, fmt.Errorf("failed to list nodes when updating Kubernetes Pod CIDRs: %w", err)
+	}
+
+	podCIDRs := make(map[string]egressv1.IPListPair)
+	for i := range nodes.Items {
+		node := &nodes.Items[i]
+		ipv4, ipv6 := getNodePodCIDRList(node)
+		if len(ipv4) == 0 && len(ipv6) == 0 {
+			continue
+		}
+		podCIDRs[node.Name] = egressv1.IPListPair{IPv4: ipv4, IPv6: ipv6}
+	}
+	return podCIDRs, nil
+}
+
+func (r *clusterInfo) listCalicoPodCIDRs(ctx context.Context) (map[string]egressv1.IPListPair, int, error) {
+	pools := new(calicov1.IPPoolList)
+	if err := r.cli.List(ctx, pools); err != nil {
+		return nil, 0, err
+	}
+
+	podCIDRs := make(map[string]egressv1.IPListPair)
+	for i := range pools.Items {
+		pool := &pools.Items[i]
+		ipv4, ipv6 := getCalicoIPPoolList(pool)
+		if len(ipv4) == 0 && len(ipv6) == 0 {
+			continue
+		}
+		podCIDRs[pool.Name] = egressv1.IPListPair{IPv4: ipv4, IPv6: ipv6}
+	}
+	return podCIDRs, len(pools.Items), nil
+}
+
+func equalIPListPairMap(a, b map[string]egressv1.IPListPair) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for name, aPair := range a {
+		bPair, ok := b[name]
+		if !ok || !utils.EqualStringSlice(aPair.IPv4, bPair.IPv4) ||
+			!utils.EqualStringSlice(aPair.IPv6, bPair.IPv6) {
+			return false
+		}
+	}
+	return true
 }
 
 func (r *clusterInfo) updateK8sServiceCIDR(ctx context.Context) error {

--- a/pkg/controller/clusterinfo/clusterinfo_test.go
+++ b/pkg/controller/clusterinfo/clusterinfo_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	calicov1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -21,93 +22,33 @@ import (
 	"github.com/spidernet-io/egressgateway/pkg/schema"
 )
 
-func TestReconcileNodeUpdatesK8sPodCIDR(t *testing.T) {
-	tests := []struct {
-		name         string
-		mode         egressv1.PodCidrMode
-		nodeIP       bool
-		node         *corev1.Node
-		expectedIPv4 []string
-		expectedIPv6 []string
-	}{
-		{
-			name:   "auto mode reads dual-stack pod CIDRs",
-			mode:   egressv1.CniTypeAuto,
-			nodeIP: true,
-			node: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
-				Spec: corev1.NodeSpec{
-					PodCIDR:  "10.244.1.0/24",
-					PodCIDRs: []string{"10.244.1.0/24", "fd00:10:244:1::/64"},
-				},
-			},
-			expectedIPv4: []string{"10.244.1.0/24"},
-			expectedIPv6: []string{"fd00:10:244:1::/64"},
-		},
-		{
-			name:   "k8s mode reads singular pod CIDR without node IP detection",
-			mode:   egressv1.CniTypeK8s,
-			nodeIP: false,
-			node: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{Name: "worker-2"},
-				Spec:       corev1.NodeSpec{PodCIDR: "10.244.2.0/24"},
-			},
-			expectedIPv4: []string{"10.244.2.0/24"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			info := &egressv1.EgressClusterInfo{
-				ObjectMeta: metav1.ObjectMeta{Name: defaultName},
-				Spec: egressv1.EgressClusterInfoSpec{AutoDetect: egressv1.AutoDetect{
-					NodeIP: tt.nodeIP, PodCidrMode: tt.mode,
-				}},
-			}
-			builder := fake.NewClientBuilder().
-				WithScheme(schema.GetScheme()).
-				WithObjects(info, tt.node).
-				WithStatusSubresource(info)
-			reconciler := &clusterInfo{cli: builder.Build()}
-
-			err := reconciler.reconcileNode(
-				context.Background(),
-				reconcile.Request{NamespacedName: types.NamespacedName{Name: tt.node.Name}},
-				logr.Discard(),
-			)
-			if !assert.NoError(t, err) {
-				return
-			}
-
-			updated := new(egressv1.EgressClusterInfo)
-			err = reconciler.cli.Get(context.Background(), client.ObjectKey{Name: defaultName}, updated)
-			if !assert.NoError(t, err) {
-				return
-			}
-
-			assert.Equal(t, tt.expectedIPv4, updated.Status.PodCIDR[tt.node.Name].IPv4)
-			assert.Equal(t, tt.expectedIPv6, updated.Status.PodCIDR[tt.node.Name].IPv6)
-		})
-	}
-}
-
-func TestReconcileNodeSkipsK8sPodCIDRInCalicoMode(t *testing.T) {
+func TestReconcileNodeUpdatesK8sPodCIDRInAutoMode(t *testing.T) {
 	info := &egressv1.EgressClusterInfo{
 		ObjectMeta: metav1.ObjectMeta{Name: defaultName},
-		Spec: egressv1.EgressClusterInfoSpec{AutoDetect: egressv1.AutoDetect{
-			NodeIP: true, PodCidrMode: egressv1.CniTypeCalico,
-		}},
+		Spec: egressv1.EgressClusterInfoSpec{
+			AutoDetect: egressv1.AutoDetect{
+				NodeIP:      true,
+				PodCidrMode: egressv1.CniTypeAuto,
+			},
+		},
 	}
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
-		Spec:       corev1.NodeSpec{PodCIDRs: []string{"10.244.1.0/24"}},
-		Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
-			{Type: corev1.NodeInternalIP, Address: "10.20.10.21"},
-		}},
+		Spec: corev1.NodeSpec{
+			PodCIDR:  "10.244.1.0/24",
+			PodCIDRs: []string{"10.244.1.0/24", "fd00:10:244:1::/64"},
+		},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.20.10.21"},
+			},
+		},
 	}
+
+	objects := []client.Object{info, node}
 	builder := fake.NewClientBuilder().
 		WithScheme(schema.GetScheme()).
-		WithObjects(info, node).
+		WithObjects(objects...).
 		WithStatusSubresource(info)
 	reconciler := &clusterInfo{cli: builder.Build()}
 
@@ -125,15 +66,107 @@ func TestReconcileNodeSkipsK8sPodCIDRInCalicoMode(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
+
+	assert.Equal(t, []string{"10.244.1.0/24"}, updated.Status.PodCIDR[node.Name].IPv4)
+	assert.Equal(t, []string{"fd00:10:244:1::/64"}, updated.Status.PodCIDR[node.Name].IPv6)
+}
+
+func TestReconcileNodeUpdatesK8sPodCIDRWhenNodeIPDetectionIsDisabled(t *testing.T) {
+	info := &egressv1.EgressClusterInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: defaultName},
+		Spec: egressv1.EgressClusterInfoSpec{
+			AutoDetect: egressv1.AutoDetect{
+				NodeIP:      false,
+				PodCidrMode: egressv1.CniTypeK8s,
+			},
+		},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+		Spec: corev1.NodeSpec{
+			PodCIDR: "10.244.1.0/24",
+		},
+	}
+
+	objects := []client.Object{info, node}
+	builder := fake.NewClientBuilder().
+		WithScheme(schema.GetScheme()).
+		WithObjects(objects...).
+		WithStatusSubresource(info)
+	reconciler := &clusterInfo{cli: builder.Build()}
+
+	err := reconciler.reconcileNode(
+		context.Background(),
+		reconcile.Request{NamespacedName: types.NamespacedName{Name: node.Name}},
+		logr.Discard(),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	updated := new(egressv1.EgressClusterInfo)
+	err = reconciler.cli.Get(context.Background(), client.ObjectKey{Name: defaultName}, updated)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Empty(t, updated.Status.NodeIP)
+	assert.Equal(t, []string{"10.244.1.0/24"}, updated.Status.PodCIDR[node.Name].IPv4)
+}
+
+func TestReconcileNodeDoesNotAddK8sPodCIDRInCalicoMode(t *testing.T) {
+	info := &egressv1.EgressClusterInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: defaultName},
+		Spec: egressv1.EgressClusterInfoSpec{
+			AutoDetect: egressv1.AutoDetect{
+				NodeIP:      true,
+				PodCidrMode: egressv1.CniTypeCalico,
+			},
+		},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+		Spec:       corev1.NodeSpec{PodCIDRs: []string{"10.244.1.0/24"}},
+		Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+			{Type: corev1.NodeInternalIP, Address: "10.20.10.21"},
+		}},
+	}
+
+	objects := []client.Object{info, node}
+	builder := fake.NewClientBuilder().
+		WithScheme(schema.GetScheme()).
+		WithObjects(objects...).
+		WithStatusSubresource(info)
+	reconciler := &clusterInfo{cli: builder.Build()}
+
+	err := reconciler.reconcileNode(
+		context.Background(),
+		reconcile.Request{NamespacedName: types.NamespacedName{Name: node.Name}},
+		logr.Discard(),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	updated := new(egressv1.EgressClusterInfo)
+	err = reconciler.cli.Get(context.Background(), client.ObjectKey{Name: defaultName}, updated)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, []string{"10.20.10.21"}, updated.Status.NodeIP[node.Name].IPv4)
 	assert.Empty(t, updated.Status.PodCIDR)
 }
 
 func TestReconcileNodeRemovesK8sPodCIDRWhenNodeIsDeleted(t *testing.T) {
 	info := &egressv1.EgressClusterInfo{
 		ObjectMeta: metav1.ObjectMeta{Name: defaultName},
-		Spec: egressv1.EgressClusterInfoSpec{AutoDetect: egressv1.AutoDetect{
-			NodeIP: true, PodCidrMode: egressv1.CniTypeK8s,
-		}},
+		Spec: egressv1.EgressClusterInfoSpec{
+			AutoDetect: egressv1.AutoDetect{
+				NodeIP:      true,
+				PodCidrMode: egressv1.CniTypeAuto,
+			},
+		},
 		Status: egressv1.EgressClusterInfoStatus{
 			NodeIP: map[string]egressv1.IPListPair{
 				"worker-1": {IPv4: []string{"10.20.10.21"}},
@@ -143,6 +176,7 @@ func TestReconcileNodeRemovesK8sPodCIDRWhenNodeIsDeleted(t *testing.T) {
 			},
 		},
 	}
+
 	builder := fake.NewClientBuilder().
 		WithScheme(schema.GetScheme()).
 		WithObjects(info).
@@ -163,8 +197,242 @@ func TestReconcileNodeRemovesK8sPodCIDRWhenNodeIsDeleted(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	assert.NotContains(t, updated.Status.NodeIP, "worker-1")
-	assert.NotContains(t, updated.Status.PodCIDR, "worker-1")
+
+	_, hasNodeIP := updated.Status.NodeIP["worker-1"]
+	_, hasPodCIDR := updated.Status.PodCIDR["worker-1"]
+	assert.False(t, hasNodeIP)
+	assert.False(t, hasPodCIDR)
+}
+
+func TestReconcileInfoSyncsExistingK8sPodCIDRs(t *testing.T) {
+	info := &egressv1.EgressClusterInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: defaultName},
+		Spec: egressv1.EgressClusterInfoSpec{
+			AutoDetect: egressv1.AutoDetect{PodCidrMode: egressv1.CniTypeAuto},
+		},
+	}
+	nodes := []client.Object{
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+			Spec:       corev1.NodeSpec{PodCIDRs: []string{"10.244.1.0/24"}},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "worker-2"},
+			Spec:       corev1.NodeSpec{PodCIDRs: []string{"10.244.2.0/24"}},
+		},
+	}
+	objects := append([]client.Object{info}, nodes...)
+	builder := fake.NewClientBuilder().
+		WithScheme(schema.GetScheme()).
+		WithObjects(objects...).
+		WithStatusSubresource(info)
+	reconciler := &clusterInfo{
+		cli:         builder.Build(),
+		watchCalico: func() {},
+	}
+
+	err := reconciler.reconcileInfo(
+		context.Background(),
+		reconcile.Request{NamespacedName: types.NamespacedName{Name: defaultName}},
+		logr.Discard(),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	updated := new(egressv1.EgressClusterInfo)
+	err = reconciler.cli.Get(context.Background(), client.ObjectKey{Name: defaultName}, updated)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, []string{"10.244.1.0/24"}, updated.Status.PodCIDR["worker-1"].IPv4)
+	assert.Equal(t, []string{"10.244.2.0/24"}, updated.Status.PodCIDR["worker-2"].IPv4)
+	assert.Equal(t, egressv1.CniTypeK8s, updated.Status.PodCidrMode)
+}
+
+func TestReconcileInfoRemovesK8sPodCIDRsWhenSwitchingToCalicoMode(t *testing.T) {
+	info := &egressv1.EgressClusterInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: defaultName},
+		Spec: egressv1.EgressClusterInfoSpec{
+			AutoDetect: egressv1.AutoDetect{PodCidrMode: egressv1.CniTypeCalico},
+		},
+		Status: egressv1.EgressClusterInfoStatus{
+			PodCIDR: map[string]egressv1.IPListPair{
+				"worker-1":          {IPv4: []string{"10.244.1.0/24"}},
+				"default-ipv4-pool": {IPv4: []string{"10.244.0.0/16"}},
+			},
+		},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+		Spec:       corev1.NodeSpec{PodCIDRs: []string{"10.244.1.0/24"}},
+	}
+	pool := &calicov1.IPPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-ipv4-pool"},
+		Spec:       calicov1.IPPoolSpec{CIDR: "10.244.0.0/16"},
+	}
+	builder := fake.NewClientBuilder().
+		WithScheme(schema.GetScheme()).
+		WithObjects(info, node, pool).
+		WithStatusSubresource(info)
+	reconciler := &clusterInfo{
+		cli:         builder.Build(),
+		watchCalico: func() {},
+	}
+
+	err := reconciler.reconcileInfo(
+		context.Background(),
+		reconcile.Request{NamespacedName: types.NamespacedName{Name: defaultName}},
+		logr.Discard(),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	updated := new(egressv1.EgressClusterInfo)
+	err = reconciler.cli.Get(context.Background(), client.ObjectKey{Name: defaultName}, updated)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	_, hasNodePodCIDR := updated.Status.PodCIDR["worker-1"]
+	assert.False(t, hasNodePodCIDR)
+	assert.Equal(t, []string{"10.244.0.0/16"}, updated.Status.PodCIDR["default-ipv4-pool"].IPv4)
+	assert.Equal(t, egressv1.CniTypeCalico, updated.Status.PodCidrMode)
+}
+
+func TestReconcileInfoAutoPrefersCalicoIPPool(t *testing.T) {
+	info := &egressv1.EgressClusterInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: defaultName},
+		Spec: egressv1.EgressClusterInfoSpec{
+			AutoDetect: egressv1.AutoDetect{PodCidrMode: egressv1.CniTypeAuto},
+		},
+		Status: egressv1.EgressClusterInfoStatus{
+			PodCidrMode: egressv1.CniTypeK8s,
+			PodCIDR: map[string]egressv1.IPListPair{
+				"worker-1": {IPv4: []string{"10.244.1.0/24"}},
+			},
+		},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+		Spec:       corev1.NodeSpec{PodCIDRs: []string{"10.244.1.0/24"}},
+	}
+	pool := &calicov1.IPPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-ipv4-pool"},
+		Spec:       calicov1.IPPoolSpec{CIDR: "192.168.0.0/16"},
+	}
+	builder := fake.NewClientBuilder().
+		WithScheme(schema.GetScheme()).
+		WithObjects(info, node, pool).
+		WithStatusSubresource(info)
+	reconciler := &clusterInfo{
+		cli:         builder.Build(),
+		watchCalico: func() {},
+	}
+
+	err := reconciler.reconcileInfo(
+		context.Background(),
+		reconcile.Request{NamespacedName: types.NamespacedName{Name: defaultName}},
+		logr.Discard(),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	updated := new(egressv1.EgressClusterInfo)
+	err = reconciler.cli.Get(context.Background(), client.ObjectKey{Name: defaultName}, updated)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	_, hasNodePodCIDR := updated.Status.PodCIDR["worker-1"]
+	assert.False(t, hasNodePodCIDR)
+	assert.Equal(t, []string{"192.168.0.0/16"}, updated.Status.PodCIDR["default-ipv4-pool"].IPv4)
+	assert.Equal(t, egressv1.CniTypeCalico, updated.Status.PodCidrMode)
+}
+
+func TestReconcileCalicoIPPoolFallsBackToK8sAfterLastPoolIsDeleted(t *testing.T) {
+	info := &egressv1.EgressClusterInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: defaultName},
+		Spec: egressv1.EgressClusterInfoSpec{
+			AutoDetect: egressv1.AutoDetect{PodCidrMode: egressv1.CniTypeAuto},
+		},
+		Status: egressv1.EgressClusterInfoStatus{
+			PodCidrMode: egressv1.CniTypeCalico,
+			PodCIDR: map[string]egressv1.IPListPair{
+				"default-ipv4-pool": {IPv4: []string{"192.168.0.0/16"}},
+			},
+		},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+		Spec:       corev1.NodeSpec{PodCIDRs: []string{"10.244.1.0/24"}},
+	}
+	builder := fake.NewClientBuilder().
+		WithScheme(schema.GetScheme()).
+		WithObjects(info, node).
+		WithStatusSubresource(info)
+	reconciler := &clusterInfo{cli: builder.Build()}
+
+	err := reconciler.reconcileCalicoIPPool(
+		context.Background(),
+		reconcile.Request{NamespacedName: types.NamespacedName{Name: "default-ipv4-pool"}},
+		logr.Discard(),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	updated := new(egressv1.EgressClusterInfo)
+	err = reconciler.cli.Get(context.Background(), client.ObjectKey{Name: defaultName}, updated)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	_, hasCalicoPool := updated.Status.PodCIDR["default-ipv4-pool"]
+	assert.False(t, hasCalicoPool)
+	assert.Equal(t, []string{"10.244.1.0/24"}, updated.Status.PodCIDR["worker-1"].IPv4)
+	assert.Equal(t, egressv1.CniTypeK8s, updated.Status.PodCidrMode)
+}
+
+func TestReconcileInfoDisablesPodCIDRDetection(t *testing.T) {
+	info := &egressv1.EgressClusterInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: defaultName},
+		Spec: egressv1.EgressClusterInfoSpec{
+			AutoDetect: egressv1.AutoDetect{PodCidrMode: egressv1.CniTypeEmpty},
+		},
+		Status: egressv1.EgressClusterInfoStatus{
+			PodCidrMode: egressv1.CniTypeK8s,
+			PodCIDR: map[string]egressv1.IPListPair{
+				"worker-1": {IPv4: []string{"10.244.1.0/24"}},
+			},
+		},
+	}
+	builder := fake.NewClientBuilder().
+		WithScheme(schema.GetScheme()).
+		WithObjects(info).
+		WithStatusSubresource(info)
+	reconciler := &clusterInfo{cli: builder.Build()}
+
+	err := reconciler.reconcileInfo(
+		context.Background(),
+		reconcile.Request{NamespacedName: types.NamespacedName{Name: defaultName}},
+		logr.Discard(),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	updated := new(egressv1.EgressClusterInfo)
+	err = reconciler.cli.Get(context.Background(), client.ObjectKey{Name: defaultName}, updated)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Empty(t, updated.Status.PodCIDR)
+	assert.Equal(t, egressv1.CniTypeEmpty, updated.Status.PodCidrMode)
 }
 
 func TestGetNodePodCIDRList(t *testing.T) {
@@ -206,7 +474,9 @@ func TestGetNodePodCIDRList(t *testing.T) {
 }
 
 func TestNodePredicateDetectsPodCIDRChanges(t *testing.T) {
-	oldNode := &corev1.Node{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.244.1.0/24"}}}
+	oldNode := &corev1.Node{
+		Spec: corev1.NodeSpec{PodCIDRs: []string{"10.244.1.0/24"}},
+	}
 	newNode := oldNode.DeepCopy()
 	newNode.Spec.PodCIDR = "10.244.2.0/24"
 	newNode.Spec.PodCIDRs = []string{"10.244.2.0/24"}

--- a/pkg/controller/clusterinfo/clusterinfo_test.go
+++ b/pkg/controller/clusterinfo/clusterinfo_test.go
@@ -1,0 +1,217 @@
+// Copyright 2022 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package clusterinfo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	egressv1 "github.com/spidernet-io/egressgateway/pkg/k8s/apis/v1beta1"
+	"github.com/spidernet-io/egressgateway/pkg/schema"
+)
+
+func TestReconcileNodeUpdatesK8sPodCIDR(t *testing.T) {
+	tests := []struct {
+		name         string
+		mode         egressv1.PodCidrMode
+		nodeIP       bool
+		node         *corev1.Node
+		expectedIPv4 []string
+		expectedIPv6 []string
+	}{
+		{
+			name:   "auto mode reads dual-stack pod CIDRs",
+			mode:   egressv1.CniTypeAuto,
+			nodeIP: true,
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+				Spec: corev1.NodeSpec{
+					PodCIDR:  "10.244.1.0/24",
+					PodCIDRs: []string{"10.244.1.0/24", "fd00:10:244:1::/64"},
+				},
+			},
+			expectedIPv4: []string{"10.244.1.0/24"},
+			expectedIPv6: []string{"fd00:10:244:1::/64"},
+		},
+		{
+			name:   "k8s mode reads singular pod CIDR without node IP detection",
+			mode:   egressv1.CniTypeK8s,
+			nodeIP: false,
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "worker-2"},
+				Spec:       corev1.NodeSpec{PodCIDR: "10.244.2.0/24"},
+			},
+			expectedIPv4: []string{"10.244.2.0/24"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := &egressv1.EgressClusterInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: defaultName},
+				Spec: egressv1.EgressClusterInfoSpec{AutoDetect: egressv1.AutoDetect{
+					NodeIP: tt.nodeIP, PodCidrMode: tt.mode,
+				}},
+			}
+			builder := fake.NewClientBuilder().
+				WithScheme(schema.GetScheme()).
+				WithObjects(info, tt.node).
+				WithStatusSubresource(info)
+			reconciler := &clusterInfo{cli: builder.Build()}
+
+			err := reconciler.reconcileNode(
+				context.Background(),
+				reconcile.Request{NamespacedName: types.NamespacedName{Name: tt.node.Name}},
+				logr.Discard(),
+			)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			updated := new(egressv1.EgressClusterInfo)
+			err = reconciler.cli.Get(context.Background(), client.ObjectKey{Name: defaultName}, updated)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			assert.Equal(t, tt.expectedIPv4, updated.Status.PodCIDR[tt.node.Name].IPv4)
+			assert.Equal(t, tt.expectedIPv6, updated.Status.PodCIDR[tt.node.Name].IPv6)
+		})
+	}
+}
+
+func TestReconcileNodeSkipsK8sPodCIDRInCalicoMode(t *testing.T) {
+	info := &egressv1.EgressClusterInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: defaultName},
+		Spec: egressv1.EgressClusterInfoSpec{AutoDetect: egressv1.AutoDetect{
+			NodeIP: true, PodCidrMode: egressv1.CniTypeCalico,
+		}},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+		Spec:       corev1.NodeSpec{PodCIDRs: []string{"10.244.1.0/24"}},
+		Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+			{Type: corev1.NodeInternalIP, Address: "10.20.10.21"},
+		}},
+	}
+	builder := fake.NewClientBuilder().
+		WithScheme(schema.GetScheme()).
+		WithObjects(info, node).
+		WithStatusSubresource(info)
+	reconciler := &clusterInfo{cli: builder.Build()}
+
+	err := reconciler.reconcileNode(
+		context.Background(),
+		reconcile.Request{NamespacedName: types.NamespacedName{Name: node.Name}},
+		logr.Discard(),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	updated := new(egressv1.EgressClusterInfo)
+	err = reconciler.cli.Get(context.Background(), client.ObjectKey{Name: defaultName}, updated)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Empty(t, updated.Status.PodCIDR)
+}
+
+func TestReconcileNodeRemovesK8sPodCIDRWhenNodeIsDeleted(t *testing.T) {
+	info := &egressv1.EgressClusterInfo{
+		ObjectMeta: metav1.ObjectMeta{Name: defaultName},
+		Spec: egressv1.EgressClusterInfoSpec{AutoDetect: egressv1.AutoDetect{
+			NodeIP: true, PodCidrMode: egressv1.CniTypeK8s,
+		}},
+		Status: egressv1.EgressClusterInfoStatus{
+			NodeIP: map[string]egressv1.IPListPair{
+				"worker-1": {IPv4: []string{"10.20.10.21"}},
+			},
+			PodCIDR: map[string]egressv1.IPListPair{
+				"worker-1": {IPv4: []string{"10.244.1.0/24"}},
+			},
+		},
+	}
+	builder := fake.NewClientBuilder().
+		WithScheme(schema.GetScheme()).
+		WithObjects(info).
+		WithStatusSubresource(info)
+	reconciler := &clusterInfo{cli: builder.Build()}
+
+	err := reconciler.reconcileNode(
+		context.Background(),
+		reconcile.Request{NamespacedName: types.NamespacedName{Name: "worker-1"}},
+		logr.Discard(),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	updated := new(egressv1.EgressClusterInfo)
+	err = reconciler.cli.Get(context.Background(), client.ObjectKey{Name: defaultName}, updated)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.NotContains(t, updated.Status.NodeIP, "worker-1")
+	assert.NotContains(t, updated.Status.PodCIDR, "worker-1")
+}
+
+func TestGetNodePodCIDRList(t *testing.T) {
+	tests := []struct {
+		name         string
+		node         *corev1.Node
+		expectedIPv4 []string
+		expectedIPv6 []string
+	}{
+		{
+			name: "dual stack pod CIDRs",
+			node: &corev1.Node{Spec: corev1.NodeSpec{
+				PodCIDRs: []string{"10.244.1.0/24", "fd00:10:244:1::/64"},
+			}},
+			expectedIPv4: []string{"10.244.1.0/24"},
+			expectedIPv6: []string{"fd00:10:244:1::/64"},
+		},
+		{
+			name:         "legacy singular pod CIDR",
+			node:         &corev1.Node{Spec: corev1.NodeSpec{PodCIDR: "10.244.2.0/24"}},
+			expectedIPv4: []string{"10.244.2.0/24"},
+		},
+		{
+			name: "invalid CIDRs are ignored",
+			node: &corev1.Node{Spec: corev1.NodeSpec{
+				PodCIDRs: []string{"invalid", "10.244.3.0/24"},
+			}},
+			expectedIPv4: []string{"10.244.3.0/24"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipv4, ipv6 := getNodePodCIDRList(tt.node)
+			assert.Equal(t, tt.expectedIPv4, ipv4)
+			assert.Equal(t, tt.expectedIPv6, ipv6)
+		})
+	}
+}
+
+func TestNodePredicateDetectsPodCIDRChanges(t *testing.T) {
+	oldNode := &corev1.Node{Spec: corev1.NodeSpec{PodCIDRs: []string{"10.244.1.0/24"}}}
+	newNode := oldNode.DeepCopy()
+	newNode.Spec.PodCIDR = "10.244.2.0/24"
+	newNode.Spec.PodCIDRs = []string{"10.244.2.0/24"}
+
+	predicate := nodePredicate{}
+	assert.True(t, predicate.Update(event.UpdateEvent{ObjectOld: oldNode, ObjectNew: newNode}))
+	assert.False(t, predicate.Update(event.UpdateEvent{ObjectOld: oldNode, ObjectNew: oldNode.DeepCopy()}))
+}

--- a/pkg/controller/clusterinfo/k8snode.go
+++ b/pkg/controller/clusterinfo/k8snode.go
@@ -26,3 +26,26 @@ func getNodeIPList(node *v1.Node) (nodeIPv4, nodeIPv6 []string) {
 	}
 	return
 }
+
+func getNodePodCIDRList(node *v1.Node) (podIPv4, podIPv6 []string) {
+	if node == nil {
+		return
+	}
+
+	podCIDRs := node.Spec.PodCIDRs
+	if len(podCIDRs) == 0 && node.Spec.PodCIDR != "" {
+		podCIDRs = []string{node.Spec.PodCIDR}
+	}
+
+	for _, cidr := range podCIDRs {
+		if isV4, err := ip.IsIPv4Cidr(cidr); err == nil && isV4 {
+			podIPv4 = append(podIPv4, cidr)
+			continue
+		}
+		if isV6, err := ip.IsIPv6Cidr(cidr); err == nil && isV6 {
+			podIPv6 = append(podIPv6, cidr)
+		}
+	}
+
+	return
+}


### PR DESCRIPTION
Fix Pod CIDR detection for clusters that use Kubernetes Node Pod CIDRs, Flannel clusters.  

## Changes

- Read `Node.spec.podCIDRs` and fall back to `Node.spec.podCIDR`.
- Make `auto` use Calico IPPools when available and otherwise fall back to Kubernetes Node Pod CIDRs.
- Keep `status.podCIDR` and `status.podCidrMode` synchronized with the effective source.
- Remove stale entries when Nodes, IPPools, or the configured mode change.
- Add unit tests for detection, source switching, deletion, dual-stack CIDRs, and fallback behavior.

## Testing

```text
go test ./pkg/controller/clusterinfo -count=1
go test -gcflags=all=-l ./pkg/... -count=1
```

Both commands passed using Go 1.24.4.

The fix was also verified with Kind v0.32.0, Kubernetes v1.36.1, and Flannel v0.28.8 in both `auto` and `k8s` modes of `spec.autoDetect.podCidrMode`.  
Pod CIDRs were detected without `extraCidr`, cluster-internal traffic remained reachable, and external traffic continued to use the configured Egress IP.  

Fixes #2086 
