### PR TITLE
fix: reconcile VXLAN peer map and MAC address

### DIFF
--- a/pkg/agent/vxlan.go
+++ b/pkg/agent/vxlan.go
@@ -551,7 +551,7 @@ func (r *vxlanReconciler) initTunnelPeerMap() error {
 		if item.Status.Phase == egressv1.EgressTunnelReady {
 			vtep := r.parseVTEP(item.Status)
 			if vtep != nil {
-				r.peerMap.Store(r.cfg.EnvConfig.NodeName, *vtep)
+				r.peerMap.Store(item.Name, *vtep)
 			}
 		}
 	}

--- a/pkg/agent/vxlan/vxlan.go
+++ b/pkg/agent/vxlan/vxlan.go
@@ -4,6 +4,7 @@
 package vxlan
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net"
@@ -265,6 +266,10 @@ func diffLink(l1, l2 netlink.Link) *conflictAttr {
 
 	v1 := l1.(*netlink.Vxlan)
 	v2 := l2.(*netlink.Vxlan)
+
+	if !bytes.Equal(v1.HardwareAddr, v2.HardwareAddr) {
+		return &conflictAttr{name: "hardware address", got: v1.HardwareAddr, exp: v2.HardwareAddr}
+	}
 
 	if v1.VxlanId != v2.VxlanId {
 		return &conflictAttr{name: "vni", got: v1.VxlanId, exp: v2.VxlanId}

--- a/pkg/agent/vxlan/vxlan_test.go
+++ b/pkg/agent/vxlan/vxlan_test.go
@@ -84,6 +84,15 @@ func TestDiffLink(t *testing.T) {
 			l2:          &netlink.Vxlan{Port: 1235},
 			expConflict: true,
 		},
+		"case9 hardware address": {
+			l1: &netlink.Vxlan{LinkAttrs: netlink.LinkAttrs{
+				HardwareAddr: net.HardwareAddr{0x66, 0x00, 0x00, 0x00, 0x00, 0x01},
+			}},
+			l2: &netlink.Vxlan{LinkAttrs: netlink.LinkAttrs{
+				HardwareAddr: net.HardwareAddr{0x66, 0x00, 0x00, 0x00, 0x00, 0x02},
+			}},
+			expConflict: true,
+		},
 	}
 
 	for name, linkCase := range cases {

--- a/pkg/agent/vxlan_test.go
+++ b/pkg/agent/vxlan_test.go
@@ -1,0 +1,70 @@
+// Copyright 2022 Authors of spidernet-io
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/spidernet-io/egressgateway/pkg/agent/vxlan"
+	"github.com/spidernet-io/egressgateway/pkg/config"
+	egressv1 "github.com/spidernet-io/egressgateway/pkg/k8s/apis/v1beta1"
+	"github.com/spidernet-io/egressgateway/pkg/schema"
+	"github.com/spidernet-io/egressgateway/pkg/utils"
+)
+
+func TestInitTunnelPeerMapUsesTunnelNames(t *testing.T) {
+	tunnels := []client.Object{
+		&egressv1.EgressTunnel{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-a"},
+			Status: egressv1.EgressTunnelStatus{
+				Phase: egressv1.EgressTunnelReady,
+				Tunnel: egressv1.Tunnel{
+					IPv4: "192.200.0.1",
+					MAC:  "66:00:00:00:00:01",
+				},
+			},
+		},
+		&egressv1.EgressTunnel{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-b"},
+			Status: egressv1.EgressTunnelStatus{
+				Phase: egressv1.EgressTunnelReady,
+				Tunnel: egressv1.Tunnel{
+					IPv4: "192.200.0.2",
+					MAC:  "66:00:00:00:00:02",
+				},
+			},
+		},
+	}
+
+	r := &vxlanReconciler{
+		client: fake.NewClientBuilder().
+			WithScheme(schema.GetScheme()).
+			WithObjects(tunnels...).
+			Build(),
+		cfg: &config.Config{
+			EnvConfig:  config.EnvConfig{NodeName: "node-a"},
+			FileConfig: config.FileConfig{EnableIPv4: true},
+		},
+		peerMap: utils.NewSyncMap[string, vxlan.Peer](),
+	}
+
+	assert.NoError(t, r.initTunnelPeerMap())
+
+	peerA, ok := r.peerMap.Load("node-a")
+	if assert.True(t, ok) {
+		assert.Equal(t, "192.200.0.1", peerA.IPv4.String())
+		assert.Equal(t, "66:00:00:00:00:01", peerA.MAC.String())
+	}
+
+	peerB, ok := r.peerMap.Load("node-b")
+	if assert.True(t, ok) {
+		assert.Equal(t, "192.200.0.2", peerB.IPv4.String())
+		assert.Equal(t, "66:00:00:00:00:02", peerB.MAC.String())
+	}
+}


### PR DESCRIPTION
## What this PR does

- keys the initial tunnel peer map by each `EgressTunnel` name instead of overwriting the local node entry while iterating
- treats a VXLAN hardware-address mismatch as a link conflict so reconciliation recreates stale links
- adds regression coverage for peer-map initialization and MAC mismatch detection

Without both changes, an agent can initialize its local VXLAN from another ready tunnel and retain that peer's MAC after the correct tunnel status is reconciled. This produces duplicate VXLAN MAC addresses and breaks return traffic.

## Tests

- `go test -mod=vendor ./pkg/agent -run ^TestInitTunnelPeerMapUsesTunnelNames$ -count=1`
- `go test -mod=vendor ./pkg/agent/vxlan -run ^TestDiffLink$ -count=1`
- remaining `pkg/agent/vxlan` unit tests under Linux/amd64, excluding the host-network-only `TestVxlan` inside Docker
- `go vet -mod=vendor ./pkg/agent ./pkg/agent/vxlan`
- `gofmt` and `git diff --check`